### PR TITLE
Build Issues: Fixes Some Build Errors and Warnings For C++17

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -138,6 +138,8 @@ if env['cross'] == 'mingw':
 
 env.Append( LINKFLAGS = [ '-static-libgcc' ] )
 
+env.Append(CCFLAGS = '-std=c++17')
+
 if env['mode'] == 'debug':
     env.Append(CCFLAGS = ['-g', '-O0'])
     #exeappend = '-debug'

--- a/src/Lib/2D/ColorTable.cpp
+++ b/src/Lib/2D/ColorTable.cpp
@@ -284,7 +284,7 @@ void ColorTable::create(
 void ColorTable::loadTable(const char *filename)
 {
     try {
-        std::auto_ptr<filesystem::ReadFile> file(filesystem::openRead(filename));
+        std::unique_ptr<filesystem::ReadFile> file(filesystem::openRead(filename));
 
     	// make sure palette in file is the same as current one
 	for(size_t i=0; i<PALETTE_LENGTH; i++) {
@@ -306,7 +306,7 @@ void ColorTable::loadTable(const char *filename)
 void ColorTable::saveTable(const char *filename) const
 {
     try {
-        std::auto_ptr<filesystem::WriteFile> file(
+        std::unique_ptr<filesystem::WriteFile> file(
                 filesystem::openWrite(filename));
 
     	file->write(&Palette::color, 768, 1);

--- a/src/Lib/2D/PackedSurface.cpp
+++ b/src/Lib/2D/PackedSurface.cpp
@@ -199,7 +199,7 @@ void PackedSurface::pack(const Surface &source)
 void PackedSurface::load(const std::string& filename)
 {
     try {
-	std::auto_ptr<filesystem::ReadFile> file(
+	std::unique_ptr<filesystem::ReadFile> file(
                 filesystem::openRead(filename));
     //LOGGER.info("Surface loaded: %s", filename.c_str());
 	free();
@@ -255,7 +255,7 @@ void PackedSurface::load(const std::string& filename)
 void PackedSurface::unload(const std::string& filename)
 {
     try {
-	std::auto_ptr<filesystem::ReadFile> file(
+	std::unique_ptr<filesystem::ReadFile> file(
                 filesystem::openRead(filename));
     //LOGGER.info("Surface loaded: %s", filename.c_str());
 	free();
@@ -276,7 +276,7 @@ void PackedSurface::unload(const std::string& filename)
 void PackedSurface::save(const std::string& filename) const
 {
     try {
-	std::auto_ptr<filesystem::WriteFile> file(
+	std::unique_ptr<filesystem::WriteFile> file(
                 filesystem::openWrite(filename));
 
 	Sint32 version = CURRENT_PAK_VERSION;

--- a/src/Lib/2D/Palette.cpp
+++ b/src/Lib/2D/Palette.cpp
@@ -292,7 +292,7 @@ void Palette::loadACT(const std::string& newname)
     name = newname;
     std::string filename = "wads/" + name + ".act";
 
-    std::auto_ptr<filesystem::ReadFile> file (filesystem::openRead(filename));
+    std::unique_ptr<filesystem::ReadFile> file (filesystem::openRead(filename));
 
     try {
 	for (int i = 0; i < 256; i++) {

--- a/src/Lib/2D/Surface.cpp
+++ b/src/Lib/2D/Surface.cpp
@@ -1494,7 +1494,7 @@ void Surface::loadBMP(const char *fileName, bool needAlloc)
 
     if (needAlloc) free();
 
-    std::auto_ptr<filesystem::ReadFile> file(
+    std::unique_ptr<filesystem::ReadFile> file(
             filesystem::openRead(fileName));
 
     try {

--- a/src/Lib/Network/Address.cpp
+++ b/src/Lib/Network/Address.cpp
@@ -108,7 +108,7 @@ Address::setPort(unsigned short port)
 
 Address
 Address::resolve(const std::string& name, unsigned short port, bool isTcp, bool forBinding)
-    throw(NetworkException)
+    throw()
 {
     LOGGER.debug("Address:: Resolving '%s':%u", name.c_str(), port);
     Address result(isTcp, forBinding);

--- a/src/Lib/Network/Address.hpp
+++ b/src/Lib/Network/Address.hpp
@@ -43,7 +43,7 @@ public:
 
     void setParams(const std::string& host, const std::string& port);
 
-    static Address resolve(const std::string& name, unsigned short port, bool isTcp = true, bool forBinding = false) throw(NetworkException);
+    static Address resolve(const std::string& name, unsigned short port, bool isTcp = true, bool forBinding = false) throw();
 
     std::string getIP() const;
 

--- a/src/Lib/Network/SocketBase.cpp
+++ b/src/Lib/Network/SocketBase.cpp
@@ -55,7 +55,7 @@ SocketBase::SocketBase()
 }
 
 SocketBase::SocketBase(const Address &a, bool isTcp)
-    throw(NetworkException)
+    throw()
     : addr(a)
 {
     state = RESOLVED;
@@ -66,7 +66,7 @@ SocketBase::SocketBase(const Address &a, bool isTcp)
 }
 
 SocketBase::SocketBase(SOCKET fd, const Address &a)
-    throw(NetworkException)
+    throw()
     : sockfd(fd), addr(a)
 {
     state = CONNECTED;
@@ -93,7 +93,7 @@ SocketBase::setAddress(const Address &a)
 }
 
 void
-SocketBase::create () throw(NetworkException)
+SocketBase::create () throw()
 {
     if ( state == RESOLVED )
     {
@@ -117,7 +117,7 @@ SocketBase::create () throw(NetworkException)
 }
 
 void
-SocketBase::setNonBlocking() throw(NetworkException)
+SocketBase::setNonBlocking() throw()
 {
     if ( state >= CREATED )
     {
@@ -143,7 +143,7 @@ SocketBase::setNonBlocking() throw(NetworkException)
 }
 
 void
-SocketBase::bindSocketTo(const Address& toaddr) throw(NetworkException)
+SocketBase::bindSocketTo(const Address& toaddr) throw()
 {
     if ( state == CONFIGURED )
     {
@@ -167,7 +167,7 @@ SocketBase::bindSocketTo(const Address& toaddr) throw(NetworkException)
 }
 
 void
-SocketBase::setReuseAddr() throw(NetworkException)
+SocketBase::setReuseAddr() throw()
 {
     if ( state == CONFIGURED )
     {
@@ -188,7 +188,7 @@ SocketBase::setReuseAddr() throw(NetworkException)
 }
 
 void
-SocketBase::setNoDelay() throw(NetworkException)
+SocketBase::setNoDelay() throw()
 {
 #ifdef _WIN32
     if ( state >= CONFIGURED ) //  && state < LISTENING
@@ -214,7 +214,7 @@ SocketBase::setNoDelay() throw(NetworkException)
 }
 
 void
-SocketBase::doListen() throw(NetworkException)
+SocketBase::doListen() throw()
 {
     if ( state == BOUND )
     {
@@ -235,7 +235,7 @@ SocketBase::doListen() throw(NetworkException)
 }
 
 void
-SocketBase::doConnect() throw(NetworkException)
+SocketBase::doConnect() throw()
 {
     if ( state == CONFIGURED )
     {
@@ -262,7 +262,7 @@ SocketBase::doConnect() throw(NetworkException)
 }
 
 int
-SocketBase::doSend(const void* data, size_t len) throw(NetworkException)
+SocketBase::doSend(const void* data, size_t len) throw()
 {
     if ( state == CONNECTED )
     {
@@ -292,7 +292,7 @@ SocketBase::doSend(const void* data, size_t len) throw(NetworkException)
 }
 
 int
-SocketBase::doReceive(void* buffer, size_t len) throw(NetworkException)
+SocketBase::doReceive(void* buffer, size_t len) throw()
 {
     if ( state == CONNECTED )
     {
@@ -327,7 +327,7 @@ SocketBase::doReceive(void* buffer, size_t len) throw(NetworkException)
 }
 
 int
-SocketBase::doSendTo(const Address& toaddr, const void* data, size_t len) throw(NetworkException)
+SocketBase::doSendTo(const Address& toaddr, const void* data, size_t len) throw()
 {
     if ( state == BOUND )
     {
@@ -353,7 +353,7 @@ SocketBase::doSendTo(const Address& toaddr, const void* data, size_t len) throw(
 }
 
 size_t
-SocketBase::doReceiveFrom(Address& fromaddr, void* buffer, size_t len) throw(NetworkException)
+SocketBase::doReceiveFrom(Address& fromaddr, void* buffer, size_t len) throw()
 {
     if ( state == BOUND || state == CONNECTED )
     {
@@ -381,7 +381,7 @@ SocketBase::doReceiveFrom(Address& fromaddr, void* buffer, size_t len) throw(Net
 }
 
 SOCKET
-SocketBase::doAccept(Address& fromaddr) throw(NetworkException)
+SocketBase::doAccept(Address& fromaddr) throw()
 {
     if ( state == LISTENING )
     {

--- a/src/Lib/Network/SocketBase.hpp
+++ b/src/Lib/Network/SocketBase.hpp
@@ -45,8 +45,8 @@ protected:
     virtual ~SocketBase();
     
     SocketBase();
-    SocketBase(const Address &a, bool isTcp) throw(NetworkException);
-    SocketBase(SOCKET fd, const Address &a) throw(NetworkException);
+    SocketBase(const Address &a, bool isTcp) throw();
+    SocketBase(SOCKET fd, const Address &a) throw();
         
     virtual void onDataReady() = 0;
     virtual void onDisconected() {}
@@ -57,24 +57,24 @@ protected:
     
     void setAddress(const Address &a);
 
-    void setReuseAddr() throw(NetworkException);
-    void setNoDelay() throw(NetworkException);
+    void setReuseAddr() throw();
+    void setNoDelay() throw();
     void doClose();
     
-    void bindSocketTo(const Address& toaddr) throw(NetworkException);
-    void bindSocket() throw(NetworkException) { bindSocketTo(addr); };
-    void doListen() throw(NetworkException);
-    void doConnect() throw(NetworkException);
-    int  doSend(const void* data, size_t len) throw(NetworkException);
-    int  doReceive(void* buffer, size_t len) throw(NetworkException);
-    int  doSendTo(const Address& toaddr, const void* data, size_t len) throw(NetworkException);
-    size_t  doReceiveFrom(Address& fromaddr, void* buffer, size_t len) throw(NetworkException);
-    SOCKET doAccept(Address& fromaddr) throw(NetworkException);
+    void bindSocketTo(const Address& toaddr) throw();
+    void bindSocket() throw() { bindSocketTo(addr); };
+    void doListen() throw();
+    void doConnect() throw();
+    int  doSend(const void* data, size_t len) throw();
+    int  doReceive(void* buffer, size_t len) throw();
+    int  doSendTo(const Address& toaddr, const void* data, size_t len) throw();
+    size_t  doReceiveFrom(Address& fromaddr, void* buffer, size_t len) throw();
+    SOCKET doAccept(Address& fromaddr) throw();
     
     void setConfigured() { state = CONFIGURED; }
 
-    void create() throw(NetworkException);
-    void setNonBlocking() throw(NetworkException);
+    void create() throw();
+    void setNonBlocking() throw();
 private:
 
     enum {

--- a/src/Lib/Network/TCPSocket.cpp
+++ b/src/Lib/Network/TCPSocket.cpp
@@ -30,14 +30,14 @@ namespace network
 {
 
 TCPSocket::TCPSocket(SOCKET fd, const Address& newaddr, TCPSocketObserver *o)
-    throw(NetworkException)
+    throw()
     : SocketBase(fd,newaddr), observer(o)
 {
     // nothing, socket is added to SocketManager because is already connected.
 }
 
 TCPSocket::TCPSocket(const std::string &host, const std::string &port, TCPSocketObserver *o)
-    throw(NetworkException)
+    throw()
     : SocketBase(), observer(o)
 {
     Address a(true, false);
@@ -46,7 +46,7 @@ TCPSocket::TCPSocket(const std::string &host, const std::string &port, TCPSocket
 }
 
 TCPSocket::TCPSocket(const Address& address, TCPSocketObserver *o)
-    throw(NetworkException)
+    throw()
     : SocketBase(address,true), observer(o)
 {
 #ifdef _WIN32
@@ -86,7 +86,7 @@ TCPSocket::destroy()
 }
 
 size_t
-TCPSocket::send(const void* data, size_t size) throw(NetworkException)
+TCPSocket::send(const void* data, size_t size) throw()
 {
     int res = doSend(data,size);
     if (!res && !observer) // disconnected

--- a/src/Lib/Network/TCPSocket.hpp
+++ b/src/Lib/Network/TCPSocket.hpp
@@ -46,12 +46,12 @@ public:
 //    TCPSocket(const Address& bindaddr, const Address& address, bool blocking = true);
 
 
-    TCPSocket(const Address& address, TCPSocketObserver *o) throw(NetworkException);
-    TCPSocket(const std::string& host,const std::string& port, TCPSocketObserver *o) throw(NetworkException);
+    TCPSocket(const Address& address, TCPSocketObserver *o) throw();
+    TCPSocket(const std::string& host,const std::string& port, TCPSocketObserver *o) throw();
 
     void destroy();
 
-    size_t send(const void* data, size_t datasize) throw(NetworkException);
+    size_t send(const void* data, size_t datasize) throw();
     
 protected:
     ~TCPSocket();
@@ -64,7 +64,7 @@ protected:
 private:
     friend class TCPListenSocket;
 
-    TCPSocket(SOCKET fd, const Address& addr, TCPSocketObserver *o) throw(NetworkException);
+    TCPSocket(SOCKET fd, const Address& addr, TCPSocketObserver *o) throw();
 
     TCPSocketObserver *observer;
 };

--- a/src/Lib/Network/UDPSocket.cpp
+++ b/src/Lib/Network/UDPSocket.cpp
@@ -26,14 +26,14 @@ namespace network
 {
 
 UDPSocket::UDPSocket(UDPSocketObserver *o)
-    throw(NetworkException) 
+    throw()
     : SocketBase(Address::ANY, false), observer(o)
 {
     bindSocket();
 }
 
 UDPSocket::UDPSocket(const Address& bindaddr, UDPSocketObserver *o)
-    throw(NetworkException)
+    throw()
     : SocketBase(bindaddr,false), observer(o)
 {
     bindSocket();
@@ -59,7 +59,7 @@ UDPSocket::onSocketError()
 
 void
 UDPSocket::send(const Address& toaddr, const void* data, size_t datasize)
-    throw(NetworkException)
+    throw()
 {
     int res = doSendTo(toaddr,data,datasize);
     if(res != (int) datasize)

--- a/src/Lib/Network/UDPSocket.hpp
+++ b/src/Lib/Network/UDPSocket.hpp
@@ -46,13 +46,13 @@ public:
      */
 //    UDPSocket(bool blocking = true);
 //    UDPSocket(const Address& bindaddr, bool blocking = true);
-    UDPSocket(UDPSocketObserver *o) throw(NetworkException);
-    UDPSocket(const Address& bindaddr, UDPSocketObserver *o) throw(NetworkException);
+    UDPSocket(UDPSocketObserver *o) throw();
+    UDPSocket(const Address& bindaddr, UDPSocketObserver *o) throw();
 
     void destroy();
 
     /** send data to the specified address */
-    void send(const Address& toaddr, const void* data, size_t datasize) throw(NetworkException);
+    void send(const Address& toaddr, const void* data, size_t datasize) throw();
 
 protected:
     ~UDPSocket();

--- a/src/NetPanzer/Classes/TileSet.cpp
+++ b/src/NetPanzer/Classes/TileSet.cpp
@@ -59,7 +59,7 @@ void TileSet::computeTileConsts( void )
 
 void TileSet::loadTileSetInfo( const char *file_path )
 {
-    std::auto_ptr<filesystem::ReadFile> file (filesystem::openRead(file_path));
+    std::unique_ptr<filesystem::ReadFile> file (filesystem::openRead(file_path));
 
     delete[] tile_data;
     tile_data = 0;
@@ -81,7 +81,7 @@ void TileSet::loadTileSet( const char *file_path )
     unsigned long  tile_buffer_size;
 
     try {
-	std::auto_ptr<filesystem::ReadFile> file(
+	std::unique_ptr<filesystem::ReadFile> file(
                 filesystem::openRead(file_path));
 
         delete[] tile_data;
@@ -119,7 +119,7 @@ void TileSet::loadTileSet( const char *file_path, WadMapTable &mapping_table )
 	unsigned long  tile_buffer_size;
 	unsigned long  tile_size;
 
-	std::auto_ptr<filesystem::ReadFile> file(
+	std::unique_ptr<filesystem::ReadFile> file(
                 filesystem::openRead(file_path));
 
 	delete[] tile_data;
@@ -203,7 +203,7 @@ void TileSet::loadTileSet( const char *file_path, WadMapTable &mapping_table )
 void TileSet::loadTileSetInfo( const char *file_path, WadMapTable &mapping_table )
 {
     try {
-	std::auto_ptr<filesystem::ReadFile> file(
+	std::unique_ptr<filesystem::ReadFile> file(
                 filesystem::openRead(file_path));
 
 	delete[] tile_data;

--- a/src/NetPanzer/Classes/TipOfDay.cpp
+++ b/src/NetPanzer/Classes/TipOfDay.cpp
@@ -25,7 +25,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 TipOfDay::TipOfDay(const std::string& filename)
 {
     try {
-        std::auto_ptr<filesystem::ReadFile> file(
+        std::unique_ptr<filesystem::ReadFile> file(
                 filesystem::openRead(filename));
 
         std::string currenttip;

--- a/src/NetPanzer/Classes/WorldMap.cpp
+++ b/src/NetPanzer/Classes/WorldMap.cpp
@@ -48,7 +48,7 @@ void WorldMap::reMap( WadMapTable &mapping_table )
 void WorldMap::loadMapFile(const std::string& filename)
 {
     try {
-	std::auto_ptr<filesystem::ReadFile> file(
+	std::unique_ptr<filesystem::ReadFile> file(
                 filesystem::openRead(filename));
 
 	if ( map_loaded == true ) {

--- a/src/NetPanzer/Views/MainMenu/Multi/MapSelectionView.cpp
+++ b/src/NetPanzer/Views/MainMenu/Multi/MapSelectionView.cpp
@@ -201,7 +201,7 @@ int MapSelectionView::loadMaps()
             std::string filename = mapsPath;
             filename += mapfiles[i];
             filename += ".npm";
-	    std::auto_ptr<filesystem::ReadFile> file
+	    std::unique_ptr<filesystem::ReadFile> file
 		(filesystem::openRead(filename));
 
 	    MapFile netPanzerMapHeader;


### PR DESCRIPTION
1. Now successfully compiles with -std=c++17 and g++11
2. c++17 removes "dynamic exception declarations". This is an easy fix.
3. c++17 deprecates auto_ptr and introduces unique_ptr and shared_ptr. We should switch to unique_ptr here.