### PR TITLE
Fix dedicated servers after SDL2 migration

### DIFF
--- a/src/NetPanzer/Core/main.cpp
+++ b/src/NetPanzer/Core/main.cpp
@@ -199,12 +199,17 @@ BaseGameManager *initialise(int argc, char** argv)
         LOGGER.setLogLevel(Logger::LEVEL_INFO);
     }
 
-    // Initialize SDL (we have to start the video subsystem as well so that
-    // the event loop is started, otherwise we'll have problems in dedicated
-    // server)
-    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER | SDL_INIT_AUDIO | SDL_INIT_EVENTS) < 0) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s", SDL_GetError());
-        exit(1);
+    // Initialize SDL (don't initialize video or audio for dedicated servers)
+    if (dedicated_option.value()) {
+        if (dedicated_option.value() && SDL_Init(SDL_INIT_TIMER | SDL_INIT_EVENTS) < 0) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s", SDL_GetError());
+            exit(1);
+        }
+    } else {
+        if (dedicated_option.value() && SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER | SDL_INIT_AUDIO | SDL_INIT_EVENTS) < 0) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s", SDL_GetError());
+            exit(1);
+        }
     }
 
     // Initialize libphysfs

--- a/src/NetPanzer/Core/main.cpp
+++ b/src/NetPanzer/Core/main.cpp
@@ -200,16 +200,9 @@ BaseGameManager *initialise(int argc, char** argv)
     }
 
     // Initialize SDL (don't initialize video or audio for dedicated servers)
-    if (dedicated_option.value()) {
-        if (dedicated_option.value() && SDL_Init(SDL_INIT_TIMER | SDL_INIT_EVENTS) < 0) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s", SDL_GetError());
-            exit(1);
-        }
-    } else {
-        if (dedicated_option.value() && SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER | SDL_INIT_AUDIO | SDL_INIT_EVENTS) < 0) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s", SDL_GetError());
-            exit(1);
-        }
+    if (dedicated_option.value() && SDL_Init(SDL_INIT_TIMER | SDL_INIT_EVENTS) < 0) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s", SDL_GetError());
+        exit(1);
     }
 
     // Initialize libphysfs


### PR DESCRIPTION
Fixes:

```
ERROR: Couldn't initialize SDL: No available video device
```
