### PR TITLE
Server should not overwrite config on error with potentially incorrect or invalid state.

### DIFF
--- a/src/NetPanzer/Interfaces/BaseGameManager.cpp
+++ b/src/NetPanzer/Interfaces/BaseGameManager.cpp
@@ -62,20 +62,20 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "Scripts/ScriptManager.hpp"
 
-BaseGameManager* gamemanager = 0;
+BaseGameManager* gamemanager = nullptr;
 
 //------------------------------------------------------------------
 BaseGameManager::BaseGameManager()
     : running(true)
 {
-    assert(gamemanager == 0);
+    assert(gamemanager == nullptr);
     gamemanager = this;
 }
 
 //------------------------------------------------------------------
 BaseGameManager::~BaseGameManager()
 {
-    gamemanager = 0;
+    gamemanager = nullptr;
 }
 
 //-----------------------------------------------------------------
@@ -88,13 +88,13 @@ void BaseGameManager::shutdownSoundSubSystem()
 {
     if(sound) {
         delete sound;
-        sound = 0;
+        sound = nullptr;
     }
 }
 //-----------------------------------------------------------------
 void BaseGameManager::initializeGameConfig(const std::string& configfile)
 {
-    if(configfile == "")
+    if(configfile.empty())
         gameconfig = new GameConfig("/config/client.cfg");
     else
         gameconfig = new GameConfig(configfile, false);
@@ -104,7 +104,7 @@ void BaseGameManager::shutdownGameConfig()
 {
     if (gameconfig) {
         delete gameconfig;
-        gameconfig = 0;
+        gameconfig = nullptr;
     }
 }
 //-----------------------------------------------------------------
@@ -155,13 +155,13 @@ void BaseGameManager::shutdownNetworkSubSystem()
         SERVER->closeSession();
         ServerMessageRouter::cleanUp();
         delete SERVER;
-        SERVER = 0;
+        SERVER = nullptr;
     }
     if(CLIENT) {
         CLIENT->partServer();
         ClientMessageRouter::cleanUp();
         delete CLIENT;
-        CLIENT = 0;
+        CLIENT = nullptr;
     }
 }
 //-----------------------------------------------------------------

--- a/src/NetPanzer/Interfaces/GameConfig.cpp
+++ b/src/NetPanzer/Interfaces/GameConfig.cpp
@@ -515,20 +515,11 @@ GameConfig::GameConfig(const std::string& luaconfigfile,bool usePhysFS)
 }
 
 GameConfig::~GameConfig()
-{
-    try
-    {
-        saveConfig();
-    }
-    catch(std::exception& e)
-    {
-        LOG(("couldn't save game configuration: %s", e.what()));
-    }
-}
+= default;
 
 void GameConfig::loadConfig()
 {
-    ScriptManager::loadConfigFile(luaconfigfile.c_str(), "config");
+    ScriptManager::loadConfigFile(luaconfigfile, "config");
 
 // these lines might be usefull infuture? 2012-01-18
 //    if(usePhysFS)
@@ -598,4 +589,4 @@ void GameConfig::saveConfig()
 
 }
 
-GameConfig* gameconfig = 0;
+GameConfig* gameconfig = nullptr;


### PR DESCRIPTION
Sometimes when the server crashes, it could overwrite the config file with a whole new one. This was due to calling `saveConfig()` in various places on shutdown and also in the `GameConfig` deconstructor, which could be called if something failed during startup and the config is not fully read.

This fixes things so `saveConfig()` is only called on a successful shutdown.