### PR TITLE
c-cpp.yml: remove unneeded install of compilers

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -49,8 +49,6 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install -y \
-          $CC \
-          $CXX \
           libsdl2-dev \
           libsdl2-mixer-dev \
           libsdl2-ttf-dev \


### PR DESCRIPTION
Trying to fix the clang build in the CI