### PR TITLE
Fixing clang + MacOS Build Errors

### DIFF
--- a/src/Lib/optionmm/command_line.cpp
+++ b/src/Lib/optionmm/command_line.cpp
@@ -25,15 +25,9 @@
     @brief  Command line parser */
 
 
-#ifndef OPTIONMM_command_line
 #include "command_line.hpp"
-#endif
-#ifndef __CSTDLIB__
 #include <cstdlib>
-#endif
-#ifndef __IOSTREAM__
 #include <iostream>
-#endif
 
 //____________________________________________________________________
 optionmm::command_line::command_line(const std::string title,

--- a/src/Lib/optionmm/command_line.hpp
+++ b/src/Lib/optionmm/command_line.hpp
@@ -204,12 +204,6 @@ struct toggle_value<bool>
     {
         x = !x;
     }
-#if defined(__GNUC__) && __GNUC__ >= 2
-    inline void operator()(std::_Bit_reference x)
-    {
-        x.flip();
-    }
-#endif
 };
 
 /// Explit specialisatation as a typedef

--- a/src/Lib/optionmm/command_line.hpp
+++ b/src/Lib/optionmm/command_line.hpp
@@ -21,18 +21,10 @@
 //
 #ifndef OPTIONMM_command_line
 #define OPTIONMM_command_line
-#ifndef OPTIONMM_optionmm
 #include <optionmm/option.hpp>
-#endif
-#ifndef __VECTOR__
 #include <vector>
-#endif
-#ifndef __STRING__
 #include <string>
-#endif
-#ifndef __IOSTREAM__
 #include <iostream>
-#endif
 
 /** @file   command_line.hh
     @author Christian Holm

--- a/src/Lib/optionmm/option.cpp
+++ b/src/Lib/optionmm/option.cpp
@@ -25,15 +25,9 @@
     @brief  Command line option  */
 
 
-#ifndef OPTIONMM_option
 #include "option.hpp"
-#endif
-#ifndef __IOSTREAM__
 #include <iostream>
-#endif
-#ifndef __IOMANIP__
 #include <iomanip>
-#endif
 #if defined(__GNUC__) && __GNUC__ <= 2
 #define CMP_ARG(s,x) x, size_t(s), x.size()
 #else

--- a/src/Lib/optionmm/option.hpp
+++ b/src/Lib/optionmm/option.hpp
@@ -22,15 +22,9 @@
 #ifndef OPTIONMM_option
 #define OPTIONMM_option
 
-#ifndef __VECTOR__
 #include <vector>
-#endif
-#ifndef __STRING__
 #include <string>
-#endif
-#ifndef __IOSTREAM__
 #include <iostream>
-#endif
 
 /** @file   option.hh
     @author Christian Holm


### PR DESCRIPTION
- Cleanup what seems to be unnecessary checks around includes in the command line library.
