### PR TITLE
cInputField.cpp: Fix memory overlap in Name Input field

### DIFF
--- a/src/NetPanzer/Views/Components/cInputField.cpp
+++ b/src/NetPanzer/Views/Components/cInputField.cpp
@@ -274,8 +274,7 @@ void cInputField::addExtendedChar(int newExtendedChar)
             if (cursorPos == strlen(destString)) {
                 break;
             }
-
-            memcpy(destString + cursorPos, destString + cursorPos + 1, strlen(destString + cursorPos + 1) + 1);
+            memmove(destString + cursorPos, destString + cursorPos + 1, strlen(destString + cursorPos + 1) + 1);
         }
         break;
 


### PR DESCRIPTION
fixes #65

According to the memcpy man page

>The  memcpy()  function copies n bytes from memory area src to memory area dest.  The memory areas must not over‐lap.  Use memmove(3) if the memory areas do overlap.

I don't know how much testing this needs. I pressed the del key and it worked as expected.

I also tested with the backspace key. Same problem. Now fixed, as far as I can tell.

