### PR TITLE
maint: fix some warnings

### DIFF
--- a/src/NetPanzer/Classes/AI/Astar.hpp
+++ b/src/NetPanzer/Classes/AI/Astar.hpp
@@ -1,16 +1,16 @@
 /*
 Copyright (C) 1998 Pyrosoft Inc. (www.pyrosoftgames.com), Matthew Bogue
- 
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
- 
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
- 
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
@@ -79,7 +79,6 @@ public:
 enum { _path_merge_front, _path_merge_rear };
 
 class AstarNodePtrCompare
-            : public std::binary_function<const AstarNode*, const AstarNode*, bool>
 {
 public:
     bool operator()(const AstarNode* node1, const AstarNode* node2) const
@@ -146,7 +145,7 @@ protected:
                                 AstarNode *succ );
 
     bool process_succ( PathList *path, int *result_code );
-    
+
 public:
     Astar();
 

--- a/src/NetPanzer/Interfaces/GameConfig.cpp
+++ b/src/NetPanzer/Interfaces/GameConfig.cpp
@@ -139,7 +139,7 @@ static const ScriptVarBindRecord video_getters[] =
 #if defined _WIN32 || defined __MINGW32__
     { "usedirectx",      GETSVTYPE_BOOLEAN, &GameConfig::video_usedirectx },
 #endif
-    {0,0}
+    {0,0,0}
 };
 
 static const ScriptVarBindRecord video_setters[] =
@@ -154,7 +154,7 @@ static const ScriptVarBindRecord video_setters[] =
 #if defined _WIN32 || defined __MINGW32__
     { "usedirectx",      SETSVTYPE_BOOLEAN, &GameConfig::video_usedirectx },
 #endif
-    {0,0}
+    {0,0,0}
 };
 
 
@@ -171,7 +171,7 @@ static const ScriptVarBindRecord interface_getters[] =
     { "rankposition_x",         GETSVTYPE_INT,     &GameConfig::interface_rankposition_x},
     { "rankposition_y",         GETSVTYPE_INT,     &GameConfig::interface_rankposition_y},
     { "viewdrawbackgroundmode", GETSVTYPE_INT,     &GameConfig::interface_viewdrawbackgroundmode},
-    {0,0}
+    {0,0,0}
 };
 
 static const ScriptVarBindRecord interface_setters[] =
@@ -187,7 +187,7 @@ static const ScriptVarBindRecord interface_setters[] =
     { "rankposition_x",         SETSVTYPE_INT,     &GameConfig::interface_rankposition_x},
     { "rankposition_y",         SETSVTYPE_INT,     &GameConfig::interface_rankposition_y},
     { "viewdrawbackgroundmode", SETSVTYPE_INT,     &GameConfig::interface_viewdrawbackgroundmode},
-    {0,0}
+    {0,0,0}
 };
 
 static const ScriptVarBindRecord game_getters[] =
@@ -222,7 +222,7 @@ static const ScriptVarBindRecord game_getters[] =
     { "mapcycle",           GETSVTYPE_STRING,  &GameConfig::game_mapcycle },
     { "mapstyle",           GETSVTYPE_STRING,  &GameConfig::game_mapstyle },
     { "units_styles",       GETSVTYPE_STRING,  &GameConfig::game_units_styles },
-    {0,0}
+    {0,0,0}
 };
 
 static const ScriptVarBindRecord game_setters[] =
@@ -257,7 +257,7 @@ static const ScriptVarBindRecord game_setters[] =
     { "mapcycle",           SETSVTYPE_STRING,  &GameConfig::game_mapcycle },
     { "mapstyle",           SETSVTYPE_STRING,  &GameConfig::game_mapstyle },
     { "units_styles",       SETSVTYPE_STRING,  &GameConfig::game_units_styles },
-    {0,0}
+    {0,0,0}
 };
 
 static const ScriptVarBindRecord sound_getters[] =
@@ -267,7 +267,7 @@ static const ScriptVarBindRecord sound_getters[] =
     { "musicvol",           GETSVTYPE_INT,     &GameConfig::sound_musicvol},
     { "effects",            GETSVTYPE_BOOLEAN, &GameConfig::sound_effects},
     { "effectsvol",         GETSVTYPE_INT,     &GameConfig::sound_effectsvol},
-    {0,0}
+    {0,0,0}
 };
 
 static const ScriptVarBindRecord sound_setters[] =
@@ -277,7 +277,7 @@ static const ScriptVarBindRecord sound_setters[] =
     { "musicvol",           SETSVTYPE_INT,     &GameConfig::sound_musicvol},
     { "effects",            SETSVTYPE_BOOLEAN, &GameConfig::sound_effects},
     { "effectsvol",         SETSVTYPE_INT,     &GameConfig::sound_effectsvol},
-    {0,0}
+    {0,0,0}
 };
 
 static const ScriptVarBindRecord radar_getters[] =
@@ -289,7 +289,7 @@ static const ScriptVarBindRecord radar_getters[] =
     { "alliedoutpostcolor", GETSVTYPE_INT,     &GameConfig::radar_alliedoutpostcolor},
     { "enemyoutpostcolor",  GETSVTYPE_INT,     &GameConfig::radar_enemyoutpostcolor},
     { "unitsize",           GETSVTYPE_INT,     &GameConfig::radar_unitsize},
-    {0,0}
+    {0,0,0}
 };
 
 static const ScriptVarBindRecord radar_setters[] =
@@ -301,7 +301,7 @@ static const ScriptVarBindRecord radar_setters[] =
     { "alliedoutpostcolor", SETSVTYPE_INT,     &GameConfig::radar_alliedoutpostcolor},
     { "enemyoutpostcolor",  SETSVTYPE_INT,     &GameConfig::radar_enemyoutpostcolor},
     { "unitsize",           SETSVTYPE_INT,     &GameConfig::radar_unitsize},
-    {0,0}
+    {0,0,0}
 };
 
 static const ScriptVarBindRecord server_getters[] =
@@ -317,7 +317,7 @@ static const ScriptVarBindRecord server_getters[] =
     { "authserver",                 GETSVTYPE_STRING,  &GameConfig::server_authserver },
     { "authentication",             GETSVTYPE_BOOLEAN, &GameConfig::server_authentication },
     { "command_burst_limit",        GETSVTYPE_INT,     &GameConfig::server_command_burst_limit },
-    {0,0}
+    {0,0,0}
 };
 
 static const ScriptVarBindRecord server_setters[] =
@@ -333,19 +333,19 @@ static const ScriptVarBindRecord server_setters[] =
     { "authserver",          SETSVTYPE_STRING,  &GameConfig::server_authserver },
     { "authentication",      SETSVTYPE_BOOLEAN, &GameConfig::server_authentication },
     { "command_burst_limit", SETSVTYPE_INT,     &GameConfig::server_command_burst_limit },
-    {0,0}
+    {0,0,0}
 };
 
 static const ScriptVarBindRecord player_getters[] =
 {
     { "name",           GETSVTYPE_STRING,  &GameConfig::player_name },
-    {0,0}
+    {0,0,0}
 };
 
 static const ScriptVarBindRecord player_setters[] =
 {
     { "name",           SETSVTYPE_STRING,  &GameConfig::player_name },
-    {0,0}
+    {0,0,0}
 };
 
 static const ScriptVarBindRecord bot_getters[] =
@@ -353,7 +353,7 @@ static const ScriptVarBindRecord bot_getters[] =
     { "class",           GETSVTYPE_INT,  &GameConfig::bot_class },
     { "allied",          GETSVTYPE_BOOLEAN,  &GameConfig::bot_allied },
     { "action_speed",    GETSVTYPE_INT,  &GameConfig::bot_action_speed },
-    {0,0}
+    {0,0,0}
 };
 
 static const ScriptVarBindRecord bot_setters[] =
@@ -361,7 +361,7 @@ static const ScriptVarBindRecord bot_setters[] =
     { "class",           SETSVTYPE_INT,  &GameConfig::bot_class },
     { "allied",          SETSVTYPE_BOOLEAN,  &GameConfig::bot_allied },
     { "action_speed",    SETSVTYPE_INT,  &GameConfig::bot_action_speed },
-    {0,0}
+    {0,0,0}
 };
 
 

--- a/src/NetPanzer/Units/UnitOpcodes.hpp
+++ b/src/NetPanzer/Units/UnitOpcodes.hpp
@@ -1,16 +1,16 @@
 /*
 Copyright (C) 1998 Pyrosoft Inc. (www.pyrosoftgames.com), Matthew Bogue
- 
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
- 
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
- 
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
@@ -40,12 +40,7 @@ struct UnitOpcodeStruct
 {
 public:
     Uint8 opcode;
-private:
-    Uint16 unit_index;
-public:
     Uint8 flags;
-private:
-    Uint8 op_data[7];
 } __attribute__((packed));
 
 typedef std::queue<UnitOpcodeStruct> UnitOpcodeQueue;

--- a/src/NetPanzer/Views/MainMenu/Multi/MasterServer/ServerQueryThread.cpp
+++ b/src/NetPanzer/Views/MainMenu/Multi/MasterServer/ServerQueryThread.cpp
@@ -31,7 +31,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Util/Log.hpp"
 #include "Util/StringUtil.hpp"
 
-static const size_t MAX_QUERIES = 4;
 static const Uint32 QUERY_TIMEOUT = 3 * 1000;
 static const Uint32 MS_TIMEOUT = 12 * 1000;
 


### PR DESCRIPTION
This fixes some repeating warnings when compiling with clang 16.0.6 such as

In file included from
../src/NetPanzer/Classes/Network/UnitNetMessage.hpp:24: ../src/NetPanzer/Units/UnitOpcodes.hpp:44:12: warning: private field 'unit_index' is not used [-Wunused-private-field]
    Uint16 unit_index;
           ^
../src/NetPanzer/Units/UnitOpcodes.hpp:48:11: warning: private field 'op_data' is not used [-Wunused-private-field]
    Uint8 op_data[7];

../src/NetPanzer/Interfaces/GameConfig.cpp:364:9: warning: missing field 'data' initializer [-Wmissing-field-initializers]
    {0,0}

../src/NetPanzer/Classes/AI/Astar.hpp:82:27: warning: 'binary_function<const AstarNode *, const AstarNode *, bool>' is depre cated [-Wdeprecated-declarations]
: public std::binary_function<const AstarNode*, const AstarNode*, bool>
                          ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/stl_function.h:141:7: note: 'binary_fun
ction<const AstarNode *, const AstarNode *, bool>' has been explicitly marked deprecated here
    } _GLIBCXX11_DEPRECATED;

../src/Lib/Network/SocketManager.cpp:123:81: warning: format specifies type 'long long' but the argument has type 'SOCKET' (aka 'int') [-Wformat]
LOGGER.debug("SocketManager:: Removing socket2
[%lld]", sb->sockfd);
~~~~    ^~~~~~~~~~