### PR TITLE
Cache Rendered Fonts

### DIFF
--- a/src/Lib/2D/CachedFontRenderer.cpp
+++ b/src/Lib/2D/CachedFontRenderer.cpp
@@ -19,8 +19,10 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <string>
 
 #include "CachedFontRenderer.hpp"
+#include "Util/Log.hpp"
 
 TTF_Font* CachedFontRenderer::font = nullptr;
+Uint32 CachedFontRenderer::lastCleanedTick = 0;
 std::unordered_map<std::string, RenderedText> CachedFontRenderer::rendered_surfaces = {};
 
 void CachedFontRenderer::initFont() {
@@ -61,7 +63,13 @@ SDL_Surface *CachedFontRenderer::render(const char *text, SDL_Color color) {
 
 void CachedFontRenderer::cleanup() {
     const Uint32 currentTick = SDL_GetTicks();
-    const Uint32 cleanupThreshold = 10000;
+    const Uint32 cleanupThreshold = 20000;
+
+    if (currentTick - lastCleanedTick < cleanupThreshold) {
+        return;
+    }
+
+    LOGGER.debug("Cached font cleanup: Begin.");
 
     // Iterate through the map to remove old RenderedText objects
     for (auto it = rendered_surfaces.begin(); it != rendered_surfaces.end();) {
@@ -73,4 +81,6 @@ void CachedFontRenderer::cleanup() {
             ++it;
         }
     }
+    lastCleanedTick = currentTick;
+    LOGGER.debug("Cached font cleanup: Done.");
 }

--- a/src/Lib/2D/CachedFontRenderer.cpp
+++ b/src/Lib/2D/CachedFontRenderer.cpp
@@ -21,9 +21,11 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "CachedFontRenderer.hpp"
 #include "Util/Log.hpp"
 
-TTF_Font* CachedFontRenderer::font = nullptr;
+const Uint32 cleanupThreshold = 20000;
+
+TTF_Font *CachedFontRenderer::font = nullptr;
 Uint32 CachedFontRenderer::lastCleanedTick = 0;
-std::unordered_map<std::string, RenderedText> CachedFontRenderer::rendered_surfaces = {};
+std::unordered_map <std::string, RenderedText> CachedFontRenderer::rendered_surfaces = {};
 
 void CachedFontRenderer::initFont() {
     if (TTF_Init() < 0) {
@@ -63,7 +65,6 @@ SDL_Surface *CachedFontRenderer::render(const char *text, SDL_Color color) {
 
 void CachedFontRenderer::cleanup() {
     const Uint32 currentTick = SDL_GetTicks();
-    const Uint32 cleanupThreshold = 20000;
 
     if (currentTick - lastCleanedTick < cleanupThreshold) {
         return;

--- a/src/Lib/2D/CachedFontRenderer.cpp
+++ b/src/Lib/2D/CachedFontRenderer.cpp
@@ -1,0 +1,76 @@
+/*
+Copyright (C) 2024 NetPanzer (https://github.com/netpanzer/), Devon Winrick, Et al.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+#include <string>
+
+#include "CachedFontRenderer.hpp"
+
+TTF_Font* CachedFontRenderer::font = nullptr;
+std::unordered_map<std::string, RenderedText> CachedFontRenderer::rendered_surfaces = {};
+
+void CachedFontRenderer::initFont() {
+    if (TTF_Init() < 0) {
+        printf("Couldn't initialize SDL TTF: %s\n", SDL_GetError());
+        exit(1);
+    }
+    // Quantico-Regular looked good too but some issues with some characters.
+    CachedFontRenderer::font = TTF_OpenFont("fonts/GNUUnifont9FullHintInstrUCSUR.ttf", FONT_SIZE);
+    TTF_SetFontStyle(CachedFontRenderer::font, TTF_STYLE_BOLD);
+    TTF_SetFontHinting(CachedFontRenderer::font, TTF_HINTING_MONO);
+}
+
+std::string CachedFontRenderer::create_cache_key(const char *text, SDL_Color color) {
+    return std::string(text) + std::to_string(color.r) +
+           std::to_string(color.g) + std::to_string(color.b);
+}
+
+SDL_Surface *CachedFontRenderer::render(const char *text, SDL_Color color) {
+    std::string key = create_cache_key(text, color);
+    auto it = rendered_surfaces.find(key);
+    if (it != rendered_surfaces.end()) {
+        // Return the cached surface
+        it->second.lastUsedTick = SDL_GetTicks();
+        return it->second.sdlSurface;
+    }
+
+    // If not found, render the text
+    SDL_Surface *rendered_surface = TTF_RenderUTF8_Solid(CachedFontRenderer::font, text, color);
+    if (rendered_surface) {
+        // Store the rendered surface in the cache
+        RenderedText text(rendered_surface, SDL_GetTicks());
+        rendered_surfaces[key] = text;
+    }
+
+    return rendered_surface;
+}
+
+void CachedFontRenderer::cleanup() {
+    const Uint32 currentTick = SDL_GetTicks();
+    const Uint32 cleanupThreshold = 10000;
+
+    // Iterate through the map to remove old RenderedText objects
+    for (auto it = rendered_surfaces.begin(); it != rendered_surfaces.end();) {
+        Uint32 lastUsedTick = it->second.lastUsedTick;
+        if (currentTick - lastUsedTick > cleanupThreshold) {
+            SDL_FreeSurface(it->second.sdlSurface); // Free SDL surface memory
+            it = rendered_surfaces.erase(it); // Remove the entry from the map
+        } else {
+            ++it;
+        }
+    }
+}

--- a/src/Lib/2D/CachedFontRenderer.hpp
+++ b/src/Lib/2D/CachedFontRenderer.hpp
@@ -37,6 +37,7 @@ public:
 
 class CachedFontRenderer {
 private:
+    static Uint32 lastCleanedTick;
     static std::unordered_map<std::string, RenderedText> rendered_surfaces;
     static std::string create_cache_key(const char *text, SDL_Color color);
     static TTF_Font* font;

--- a/src/Lib/2D/CachedFontRenderer.hpp
+++ b/src/Lib/2D/CachedFontRenderer.hpp
@@ -1,0 +1,50 @@
+/*
+Copyright (C) 2024 NetPanzer (https://github.com/netpanzer/), Devon Winrick, Et al.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+#ifndef NETPANZER_FONTPOOL_HPP
+#define NETPANZER_FONTPOOL_HPP
+
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_ttf.h>
+#include <unordered_map>
+
+#define FONT_SIZE 14
+#define FONT_WIDTH 14
+
+class RenderedText {
+public:
+    SDL_Surface* sdlSurface;
+    Uint32 lastUsedTick;
+
+    RenderedText() : sdlSurface(nullptr), lastUsedTick(0) {}
+    RenderedText(SDL_Surface* surface, Uint32 tick) : sdlSurface(surface), lastUsedTick(tick) {}
+};
+
+class CachedFontRenderer {
+private:
+    static std::unordered_map<std::string, RenderedText> rendered_surfaces;
+    static std::string create_cache_key(const char *text, SDL_Color color);
+    static TTF_Font* font;
+public:
+    static void initFont();
+    static SDL_Surface* render(const char *text, SDL_Color color);
+    static void cleanup();
+};
+
+
+#endif //NETPANZER_FONTPOOL_HPP

--- a/src/Lib/2D/Surface.hpp
+++ b/src/Lib/2D/Surface.hpp
@@ -22,20 +22,15 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <assert.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <SDL2/SDL.h>
 
 #include "Types/iXY.hpp"
 #include "Types/iRect.hpp"
 #include "Util/NoCopy.hpp"
 
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_ttf.h>
-
 class ColorTable;
 class Palette;
 typedef Uint8 PIX;
-
-// This must be called before any of the string blitting functions are used.
-void initFont();
 
 /////////////////////////////////////////////////////////////////////////////
 // class Surface

--- a/src/NetPanzer/Interfaces/PlayerGameManager.cpp
+++ b/src/NetPanzer/Interfaces/PlayerGameManager.cpp
@@ -55,6 +55,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Classes/Network/ConnectNetMessage.hpp"
 #include "Units/UnitGlobals.hpp"
 
+#include "2D/CachedFontRenderer.hpp"
 #include "2D/Palette.hpp"
 #include "Views/Components/Desktop.hpp"
 #include "Views/Components/ViewGlobals.hpp"
@@ -133,7 +134,7 @@ void PlayerGameManager::initializeVideoSubSystem()
     LOGGER.info("Initializing video mode");
     sdlVideo = new SDLVideo();
     Screen = sdlVideo;
-    initFont();
+    CachedFontRenderer::initFont();
     GameManager::setVideoMode();
 }
 
@@ -255,6 +256,7 @@ void PlayerGameManager::graphicsLoop()
 
     screen->unlock();
     screen->render();
+    CachedFontRenderer::cleanup();
 }
 //-----------------------------------------------------------------
 bool PlayerGameManager::launchNetPanzerGame()

--- a/src/NetPanzer/meson.build
+++ b/src/NetPanzer/meson.build
@@ -110,12 +110,13 @@ foreach file : src_basename
 endforeach
 
 src_basename = [
+  'CachedFontRenderer.cpp',
+  'Color.cpp',
+  'ColorTable.cpp',
+  'PackedSurface.cpp',
   'Palette.cpp',
   'Span.cpp',
-  'PackedSurface.cpp',
-  'ColorTable.cpp',
-  'Surface.cpp',
-  'Color.cpp'
+  'Surface.cpp'
 ]
 foreach file : src_basename
   src += [join_paths('../Lib/2D', file)]


### PR DESCRIPTION
Addresses #10 

This puts the font rendering in a pool of surfaces, cached by text and color. This is an optimization to prevent random allocations per-frame. It periodically garbage collects, on a safe interval to prevent memory leaks. Based on testing this does not cause any dropped frames with the current number of rendered fonts.