### PR TITLE
meson: Enable sanitize

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,9 @@ project(
   meson_version : '>= 0.56.2',
   default_options: [
     'warning_level=1',
-    'cpp_std=c++17'
+    'cpp_std=c++17',
+    'b_sanitize=address,undefined',
+    'b_lundef=false'
     ]
   )
 


### PR DESCRIPTION
We might consider leaving this as the default for a while. It might help us catch existing bugs or prevent introducing new ones.

It can be turned off by using 'meson configure -Db_sanitize=none -Db_lundef=true' from the build directory.

I'm not too sure what the l_undef does, but meson warns about some potential clang compatibility when using b_sanitize=address,undefined with lundef set to true (the default).