### PR TITLE
Mouse Movement Fixes (Jerky Movement etc)

### DIFF
--- a/src/NetPanzer/Classes/WorldInputCmdProcessor.cpp
+++ b/src/NetPanzer/Classes/WorldInputCmdProcessor.cpp
@@ -150,12 +150,6 @@ void WorldInputCmdProcessor::updateScrollStatus(const iXY &mouse_pos) {
     return;
   }
 
-  if (GameConfig::video_fullscreen != true) {
-    // don't do border scrolling on windowed mode because
-    //  the window isn't always on the edge of the screen.
-    return;
-  }
-
   if ((unsigned int)mouse_pos.x >= (screen->getWidth() - 1)) {
     WorldViewInterface::scroll_right(scroll_increment);
   }

--- a/src/NetPanzer/Interfaces/MouseInterface.hpp
+++ b/src/NetPanzer/Interfaces/MouseInterface.hpp
@@ -22,9 +22,11 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include <deque>
 #include <map>
+#include <math.h>
 #include <string>
 
 #include "2D/Surface.hpp"
+#include "Classes/ScreenSurface.hpp"
 #include "Util/NTimer.hpp"
 
 class MouseEvent {
@@ -105,8 +107,9 @@ class MouseInterface {
 
   static void setCursor(const char *cursorname);
   static inline void onMouseMoved(SDL_MouseMotionEvent *e) {
-    mouse_pos.x = e->x;
-    mouse_pos.y = e->y;
+      // min/max here keep cursor in window, always visible, even when we have black bars
+      mouse_pos.x = std::min(std::max(e->x, 0), (int) screen->getWidth());
+      mouse_pos.y = std::min(std::max(e->y, 0), (int) screen->getHeight());
   }
 
   static inline iXY getMousePosition() { return mouse_pos; }

--- a/src/NetPanzer/System/SDLVideo.cpp
+++ b/src/NetPanzer/System/SDLVideo.cpp
@@ -192,6 +192,7 @@ bool SDLVideo::setVideoMode(int new_width, int new_height, int bpp,
   int centerY = new_height / 2;
   LOGGER.debug("Warping mouse into window...");
   SDL_WarpMouseInWindow(window, centerX, centerY);
+  SDL_SetWindowGrab(window, fullscreen ? SDL_TRUE : SDL_FALSE);
   return true;
 }
 


### PR DESCRIPTION
Fixes #74 

1. Map movement via mouse on edge of window no longer jerky.
2. Mouse doesn't go beyond black bars.
3. Mouse doesn't go onto 2nd monitor in fullscreen mode.
4. Mouse can leave windowed mode but you can use edge of map movement.