### PR TITLE
Fixes Not Compiling on Windows

### DIFF
--- a/src/Lib/2D/CachedFontRenderer.cpp
+++ b/src/Lib/2D/CachedFontRenderer.cpp
@@ -19,7 +19,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "CachedFontRenderer.hpp"
 
-#include <filesystem>
 #include <string>
 
 #include "Util/FileSystem.hpp"

--- a/src/Lib/2D/CachedFontRenderer.cpp
+++ b/src/Lib/2D/CachedFontRenderer.cpp
@@ -39,10 +39,11 @@ void CachedFontRenderer::initFont() {
   }
   // Quantico-Regular looked good too but some issues with some characters.
   const std::filesystem::path absFontPath = std::string(filesystem::getRealName("/fonts/GNUUnifont9FullHintInstrUCSUR.ttf"));
+  const char * fontPathChar = (char*) absFontPath.c_str();
   CachedFontRenderer::font =
-      TTF_OpenFont(absFontPath.c_str(), FONT_SIZE);
+      TTF_OpenFont(fontPathChar, FONT_SIZE);
   if (font == NULL) {
-    fprintf (stderr, "%s:%d:%s not found.\n", __func__, __LINE__, absFontPath.c_str());
+    LOGGER.warning("CachedFontRenderer - cannot load font %s.", fontPathChar);
     exit (EXIT_FAILURE);
   }
 

--- a/src/Lib/2D/CachedFontRenderer.cpp
+++ b/src/Lib/2D/CachedFontRenderer.cpp
@@ -34,8 +34,8 @@ std::unordered_map<std::string, RenderedText>
 
 void CachedFontRenderer::initFont() {
   if (TTF_Init() < 0) {
-    printf("Couldn't initialize SDL TTF: %s\n", SDL_GetError());
-    exit(1);
+    LOGGER.warning("Couldn't initialize SDL TTF: %s\n", SDL_GetError());
+    exit(EXIT_FAILURE);
   }
   // Quantico-Regular looked good too but some issues with some characters.
   const std::filesystem::path absFontPath = std::string(filesystem::getRealName("/fonts/GNUUnifont9FullHintInstrUCSUR.ttf"));

--- a/src/Lib/2D/CachedFontRenderer.cpp
+++ b/src/Lib/2D/CachedFontRenderer.cpp
@@ -38,12 +38,11 @@ void CachedFontRenderer::initFont() {
     exit(EXIT_FAILURE);
   }
   // Quantico-Regular looked good too but some issues with some characters.
-  const std::filesystem::path absFontPath = std::string(filesystem::getRealName("/fonts/GNUUnifont9FullHintInstrUCSUR.ttf"));
-  const char * fontPathChar = (char*) absFontPath.c_str();
+  const std::string absFontPath = std::string(filesystem::getRealName("/fonts/GNUUnifont9FullHintInstrUCSUR.ttf"));
   CachedFontRenderer::font =
-      TTF_OpenFont(fontPathChar, FONT_SIZE);
+      TTF_OpenFont(absFontPath.c_str(), FONT_SIZE);
   if (font == NULL) {
-    LOGGER.warning("CachedFontRenderer - cannot load font %s.", fontPathChar);
+    LOGGER.warning("CachedFontRenderer - cannot load font %s.", absFontPath.c_str());
     exit (EXIT_FAILURE);
   }
 


### PR DESCRIPTION
Technically direct cast to char* from w_char* is not correct, but unblocks build for now. Changed type from filesystem::path to string... hopefully nobody puts super fancy characters in file system paths :) netpanzer does not support it.

Error:

```
src\\Lib\\2D\\CachedFontRenderer.cpp: In static member function \'static void CachedFontRenderer::initFont()\':\nsrc\\Lib\\2D\\CachedFontRenderer.cpp:43:37: error: cannot convert \'con
st std::filesystem::__cxx11::path::value_type*\' {aka \'const wchar_t*\'} to \'const char*\'\n   43 |       TTF_OpenFont(absFontPath.c_str(), FONT_SIZE);\n      |                    ~~~~
~~~~~~~~~~~~~^~\n      |                                     |\n      |                                     const std::filesystem::__cxx11::path::value_type* {aka const wchar_t*}\nIn fil
e included from src\\Lib\\2D\\CachedFontRenderer.hpp:24,\n                 from src\\Lib\\2D\\CachedFontRenderer.cpp:20:\nC:/MinGW/include/SDL2/SDL_ttf.h:205:61: note:   initializing arg
ument 1 of \'TTF_Font* TTF_OpenFont(const char*, int)\'\n  205 | extern DECLSPEC TTF_Font * SDLCALL TTF_OpenFont(const char *file, int ptsize);\n      |
               ~~~~~~~~~~~~^~~~\nsrc\\Lib\\2D\\CachedFontRenderer.cpp:45:30: warning: format \'%s\' expects argument of type \'char*\', but argument 5 has type \'const std::filesystem::_
_cxx11::path::value_type*\' {aka \'const wchar_t*\'} [-Wformat=]\n   45 |     fprintf (stderr, "%s:%d:%s not found.\\n", __func__, __LINE__, absFontPath.c_str());\n      |
              ~^                                    ~~~~~~~~~~~~~~~~~~~\n      |                              |                                                     |\n      |
                  char*                                                 const std::filesystem::__cxx11::path::value_type* {aka const wchar_t*}\n      |                             %ls\n'
=====
scons: *** [build\release\src\Lib\2D\CachedFontRenderer.o] Error 1

```

(sorry, still using scons on windows box)
