### PR TITLE
meson: temporarily disable sanitize

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,8 +6,8 @@ project(
   default_options: [
     'warning_level=2',
     'cpp_std=c++17',
-    'b_sanitize=address,undefined',
-    'b_lundef=false'
+#    'b_sanitize=address,undefined',
+#    'b_lundef=false'
     ]
   )
 


### PR DESCRIPTION
Right now when it's enabled, NP crashes before it gets to the main menu. I think we should disable it until the game can actually be played.