### PR TITLE
Fixes Random Crash

### DIFF
--- a/src/NetPanzer/Particles/ParticleInterface.cpp
+++ b/src/NetPanzer/Particles/ParticleInterface.cpp
@@ -978,6 +978,9 @@ void ParticleInterface::addMoveDirtPuff(const UnitState &unitState) {
   if (TileInterface::getWorldPixMovementValue(unitState.location.x,
                                               unitState.location.y) == 0) {
     if (movePuffWaitGroup >= movePuffWaitTotal) {
+      if (unitParticleInfo.empty()) {
+          getUnitParticleInfo();
+      }
       iXY size = unitParticleInfo[unitState.unit_type].minBounds.getSize();
 
       assert(size.x > 0 && size.y > 0);


### PR DESCRIPTION
Seems to fix it. Got crash before, don't now. Don't know flow well enough yet to why the vector is empty here but it crashes randomly due to the rand() further up in this method, I think.