### PR TITLE
Adding Proximity Audio For Hits and Explosions, Fixes Variable Audio Broken

### DIFF
--- a/src/NetPanzer/Particles/ParticleInterface.cpp
+++ b/src/NetPanzer/Particles/ParticleInterface.cpp
@@ -504,9 +504,6 @@ void ParticleInterface::testSim() {
   if (groupTime0 > 1.0f) {
     groupTime0 = 0.0f;
 
-    // SFX
-    sound->playSound("expl");
-
     iRect gameViewRect;
     WorldViewInterface::getViewWindow(&gameViewRect);
 
@@ -516,6 +513,9 @@ void ParticleInterface::testSim() {
         gameViewRect.min.x + 100 + (rand() % (gameViewRect.getSizeX() - 200));
     unitState.location.y =
         gameViewRect.min.y + 100 + (rand() % (gameViewRect.getSizeY() - 200));
+
+    // SFX
+    sound->playAmbientSound("expl", WorldViewInterface::getCameraDistance(unitState.location));
 
     // Hack until all the units are actually used.
     unitState.unit_type = rand() % UnitProfileInterface::getNumUnitTypes();
@@ -527,9 +527,6 @@ void ParticleInterface::testSim() {
   if (groupTime1 > 0.5f) {
     groupTime1 = 0.0f;
 
-    // SFX
-    sound->playSound("expl");
-
     iRect gameViewRect;
     WorldViewInterface::getViewWindow(&gameViewRect);
 
@@ -539,6 +536,9 @@ void ParticleInterface::testSim() {
         gameViewRect.min.x + 100 + (rand() % (gameViewRect.getSizeX() - 200));
     location.y =
         gameViewRect.min.y + 100 + (rand() % (gameViewRect.getSizeY() - 200));
+
+    // SFX
+    sound->playAmbientSound("expl", WorldViewInterface::getCameraDistance(location));
 
     addMiss(location, rand() % UnitProfileInterface::getNumUnitTypes());
   }

--- a/src/NetPanzer/System/SDLSound.cpp
+++ b/src/NetPanzer/System/SDLSound.cpp
@@ -135,8 +135,10 @@ void SDLSound::playAmbientSound(const char *name, long distance) {
   SoundData *sdata = findChunk(name);
   if (sdata) {
     if (sdata->last_played.isTimeOut()) {
+      int newVolume = getSoundVolume(distance);
+//      printf("playing %s at %d\n", name, newVolume);
       int oldVolume =
-          Mix_VolumeChunk(sdata->getData(), getSoundVolume(distance));
+          Mix_VolumeChunk(sdata->getData(), newVolume);
       if (Mix_PlayChannel(-1, sdata->getData(), 0) == -1) {
         // LOG (("Couldn't play sound '%s': %s", name, Mix_GetError()));
       }

--- a/src/NetPanzer/System/SDLSound.cpp
+++ b/src/NetPanzer/System/SDLSound.cpp
@@ -136,13 +136,11 @@ void SDLSound::playAmbientSound(const char *name, long distance) {
   if (sdata) {
     if (sdata->last_played.isTimeOut()) {
       int newVolume = getSoundVolume(distance);
-//      printf("playing %s at %d\n", name, newVolume);
-      int oldVolume =
-          Mix_VolumeChunk(sdata->getData(), newVolume);
+//      printf("playing %s at distance %ld and volume %d\n", name, distance, newVolume);
+      Mix_VolumeChunk(sdata->getData(), newVolume);
       if (Mix_PlayChannel(-1, sdata->getData(), 0) == -1) {
         // LOG (("Couldn't play sound '%s': %s", name, Mix_GetError()));
       }
-      Mix_VolumeChunk(sdata->getData(), oldVolume);
       sdata->last_played.reset();
     } else {
       //            LOGGER.debug("Skipped ambient sound '%s' due to timeout",
@@ -183,16 +181,16 @@ int SDLSound::getSoundVolume(long distance) {
   if ((distance < 640000)) return MIX_MAX_VOLUME;
 
   // 2 to 4 800x600 screen widths away--
-  if ((distance < 10240000)) return int(0.75 * MIX_MAX_VOLUME);
+  if ((distance < 10240000)) return int(0.2 * MIX_MAX_VOLUME);
 
   // 4 to 8 800x600 screen widths away--
-  if ((distance < 40960000)) return int(0.5 * MIX_MAX_VOLUME);
+  if ((distance < 40960000)) return int(0.1 * MIX_MAX_VOLUME);
 
   // 8 to 12 800x600 screen widths away--
-  if ((distance < 92760000)) return int(0.25 * MIX_MAX_VOLUME);
+  if ((distance < 92760000)) return int(0.05 * MIX_MAX_VOLUME);
 
   // 12 to 16 800x600 screen widths away--
-  if ((distance < 163840000)) return int(0.05 * MIX_MAX_VOLUME);
+  if ((distance < 163840000)) return int(0.02 * MIX_MAX_VOLUME);
 
   // anything further away--
   return 0;

--- a/src/NetPanzer/System/Sound.cpp
+++ b/src/NetPanzer/System/Sound.cpp
@@ -30,6 +30,7 @@ Sound::Sound() {
  * Play "tankidle" repeatedly.
  */
 void Sound::playTankIdle() {
+  // TODO - play audio volume based on closest unit to player
   m_tankIdleChannel = playSoundRepeatedly("tankidle");
 }
 

--- a/src/NetPanzer/Weapons/Weapon.cpp
+++ b/src/NetPanzer/Weapons/Weapon.cpp
@@ -114,7 +114,7 @@ void Weapon::fsmFlight(void) {
         lifecycle_status = _lifecycle_weapon_in_active;
 
         // SFX
-        sound->playSound("hit_target");
+        sound->playAmbientSound("hit_target", WorldViewInterface::getCameraDistance(location));
 
         // **  Particle Shit
         iXY loc = iXY(location.x, location.y);


### PR DESCRIPTION
- Now everything on the map is not 100% volume all the time (very annoying w/ large matches).
- Fixes playAmbientSound() not respecting distance parameter.
- Adjusted distances some based on what feels nice.
- Users can still look at mini map to see if they're being attacked etc.
