### PR TITLE
CI: Update image:tag for arm64 container in cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,7 +30,7 @@ arm_task:
   <<: *filter_template
   name: Ubuntu arm64
   arm_container:
-    image: andy5995/netpanzer-build-env:jammy
+    image: andy5995/netpanzer:build-env-latest
   setup_script:
   - ./setup-build.sh _build
   build_script:


### PR DESCRIPTION
Changed by
https://github.com/netpanzer/netpanzer/commit/d527e1293af5d6043ceaf14266d908aa82919b00