### PR TITLE
meson: Use alpha chars in version number

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'netpanzer',
   ['c', 'cpp'],
-  version: '0.9.0.07.555',
+  version: '0.9.0-rc8',
   meson_version : '>= 0.59.0',
   default_options: [
     'warning_level=2',

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'netpanzer',
   ['c', 'cpp'],
-  version: '0.9.0-rc8',
+  version: '0.9.0-rc8-dev',
   meson_version : '>= 0.59.0',
   default_options: [
     'warning_level=2',


### PR DESCRIPTION
I thought meson didn't allow this but I was wrong.