### PR TITLE
Fix code scanning alert no. 35: Multiplication result converted to larger type

### DIFF
--- a/src/Lib/2D/Surface.hpp
+++ b/src/Lib/2D/Surface.hpp
@@ -223,12 +223,12 @@ class Surface : public NoCopy {
   void bltHLine(int x1, int y, int x2, const PIX table[]);
 
   void frameToBuffer(Uint8 *dest, size_t dest_len) {
-    size_t frame_len = getPitch() * getHeight();
+    size_t frame_len = static_cast<size_t>(getPitch()) * getHeight();
     memcpy(dest, mem, std::min(frame_len, dest_len));
   }
 
   void bufferToFrame(const Uint8 *src, const size_t src_len) {
-    size_t frame_len = getPitch() * getHeight();
+    size_t frame_len = static_cast<size_t>(getPitch()) * getHeight();
     memcpy(mem, src, std::min(frame_len, src_len));
   }
   bool isInBounds(unsigned int x, unsigned int y) const;


### PR DESCRIPTION
Fixes [https://github.com/netpanzer/netpanzer/security/code-scanning/35](https://github.com/netpanzer/netpanzer/security/code-scanning/35)

To fix the problem, we need to ensure that the multiplication is performed using the larger type `size_t` to prevent overflow. This can be achieved by casting one of the operands to `size_t` before performing the multiplication. This way, the multiplication will be done in the larger type, and the result will be correctly assigned to the `size_t` variable `frame_len`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
