### PR TITLE
Adding Bounds Check for Heap Buffer Overflow

### DIFF
--- a/src/Lib/ArrayUtil/BitArray.cpp
+++ b/src/Lib/ArrayUtil/BitArray.cpp
@@ -107,6 +107,10 @@ void BitArray::clearBit(unsigned long x, unsigned long y) {
 
 //************************************************************************
 bool BitArray::getBit(unsigned long x, unsigned long y) {
+  if (x >= x_size || y >= y_size) {
+    return false;
+  }
+
   unsigned long index;
   unsigned char shift;
   unsigned char mask = 1;
@@ -116,6 +120,10 @@ bool BitArray::getBit(unsigned long x, unsigned long y) {
   shift = (unsigned char)(7 - (index & (unsigned long)7));
   index = index >> 3;
   mask = (mask << shift);
+
+  if (index > size) {
+    return false;
+  }
 
   value = array[index] & mask;
 


### PR DESCRIPTION
Fixes https://github.com/netpanzer/netpanzer/issues/250

It would be good to know *how* these out of bounds values could be created. AFAIK they are created like this:

```
    map_size_x = MapInterface::getWidth();
    map_size_y = MapInterface::getHeight();

    loc.x = rand() % map_size_x;
    loc.y = rand() % map_size_y;
    if (MapInterface::getMovementValue(loc) == 0xFF) {
```

