### PR TITLE
Fixes Bots Crashing - Always use physfs

### DIFF
--- a/src/Lib/Util/Log.cpp
+++ b/src/Lib/Util/Log.cpp
@@ -49,7 +49,7 @@ const int Logger::LEVEL_WARNING = 4;
  * Default log level is INFO.
  */
 Logger::Logger() {
-  m_logLevel = LEVEL_WARNING;
+  m_logLevel = LEVEL_INFO;
   m_logfile = 0;
   used_size = 0;
 }

--- a/src/NetPanzer/Interfaces/BaseGameManager.cpp
+++ b/src/NetPanzer/Interfaces/BaseGameManager.cpp
@@ -80,8 +80,7 @@ void BaseGameManager::shutdownSoundSubSystem() {
 }
 //-----------------------------------------------------------------
 void BaseGameManager::initializeGameConfig(const std::string& configfile) {
-  gameconfig = new GameConfig(configfile.empty() ? "/config/client.cfg" : configfile,
-                              configfile.empty());
+  gameconfig = new GameConfig(configfile.empty() ? "/config/client.cfg" : configfile);
 
   // cleanup/saving of game config is done in main and depends on shutdown
   // process

--- a/src/NetPanzer/Interfaces/BotGameManager.cpp
+++ b/src/NetPanzer/Interfaces/BotGameManager.cpp
@@ -86,7 +86,7 @@ void BotGameManager::initializeGameConfig(const std::string& configfile) {
   if (configfile == "")
     gameconfig = new GameConfig("/config/bot.cfg");
   else
-    gameconfig = new GameConfig(configfile, false);
+    gameconfig = new GameConfig(configfile);
 }
 
 void BotGameManager::initializeVideoSubSystem() {

--- a/src/NetPanzer/Interfaces/BotGameManager.cpp
+++ b/src/NetPanzer/Interfaces/BotGameManager.cpp
@@ -87,6 +87,7 @@ void BotGameManager::initializeGameConfig(const std::string& configfile) {
     gameconfig = new GameConfig("/config/bot.cfg");
   else
     gameconfig = new GameConfig(configfile, false);
+  gameconfig->saveConfig();
 }
 
 void BotGameManager::initializeVideoSubSystem() {

--- a/src/NetPanzer/Interfaces/BotGameManager.cpp
+++ b/src/NetPanzer/Interfaces/BotGameManager.cpp
@@ -83,7 +83,7 @@ BotGameManager::BotGameManager(const std::string& serverHost)
  * Bot uses name = playername + "-" + rand() % 1000
  */
 void BotGameManager::initializeGameConfig(const std::string& configfile) {
-  if (configfile == "")
+  if (configfile.empty())
     gameconfig = new GameConfig("/config/bot.cfg");
   else
     gameconfig = new GameConfig(configfile);

--- a/src/NetPanzer/Interfaces/BotGameManager.cpp
+++ b/src/NetPanzer/Interfaces/BotGameManager.cpp
@@ -87,7 +87,6 @@ void BotGameManager::initializeGameConfig(const std::string& configfile) {
     gameconfig = new GameConfig("/config/bot.cfg");
   else
     gameconfig = new GameConfig(configfile, false);
-  gameconfig->saveConfig();
 }
 
 void BotGameManager::initializeVideoSubSystem() {

--- a/src/NetPanzer/Interfaces/DedicatedGameManager.cpp
+++ b/src/NetPanzer/Interfaces/DedicatedGameManager.cpp
@@ -80,7 +80,7 @@ void DedicatedGameManager::initializeGameConfig(const std::string& configfile) {
   if (configfile == "")
     gameconfig = new GameConfig("/config/server.cfg");
   else
-    gameconfig = new GameConfig(configfile, false);
+    gameconfig = new GameConfig(configfile);
 }
 //-----------------------------------------------------------------
 void DedicatedGameManager::initializeInputDevices() {

--- a/src/NetPanzer/Interfaces/DedicatedGameManager.cpp
+++ b/src/NetPanzer/Interfaces/DedicatedGameManager.cpp
@@ -77,7 +77,7 @@ void DedicatedGameManager::shutdownVideoSubSystem() {
 
 //-----------------------------------------------------------------
 void DedicatedGameManager::initializeGameConfig(const std::string& configfile) {
-  if (configfile == "")
+  if (configfile.empty())
     gameconfig = new GameConfig("/config/server.cfg");
   else
     gameconfig = new GameConfig(configfile);

--- a/src/NetPanzer/Interfaces/GameConfig.cpp
+++ b/src/NetPanzer/Interfaces/GameConfig.cpp
@@ -478,6 +478,7 @@ GameConfig::~GameConfig() = default;
 void GameConfig::loadConfig() {
 
   ScriptManager::loadConfigFile(luaconfigfile, "config", this->usePhysFS);
+  saveConfig();
 
   if (player_name->length() == 0) {
     std::stringstream default_player;

--- a/src/NetPanzer/Interfaces/GameConfig.cpp
+++ b/src/NetPanzer/Interfaces/GameConfig.cpp
@@ -478,7 +478,6 @@ GameConfig::~GameConfig() = default;
 void GameConfig::loadConfig() {
 
   ScriptManager::loadConfigFile(luaconfigfile, "config", this->usePhysFS);
-  saveConfig();
 
   if (player_name->length() == 0) {
     std::stringstream default_player;

--- a/src/NetPanzer/Interfaces/GameConfig.cpp
+++ b/src/NetPanzer/Interfaces/GameConfig.cpp
@@ -446,7 +446,7 @@ void GameConfig::registerScript(const NPString& table_name) {
                                      bot_getters, bot_setters);
 }
 
-GameConfig::GameConfig(const std::string& luaconfigfile, bool usePhysFS)
+GameConfig::GameConfig(const std::string& luaconfigfile)
     // VariableName("Name", value [, minimum, maximum])
     : hostorjoin("hostorjoin", _game_session_join, 0, _game_session_last - 1),
       quickConnect("quickconnect", false),
@@ -455,7 +455,6 @@ GameConfig::GameConfig(const std::string& luaconfigfile, bool usePhysFS)
 
 {
   this->luaconfigfile = luaconfigfile;
-  this->usePhysFS = usePhysFS;
 
   std::stringstream default_player;
   default_player << "Player" << (rand() % 1000);
@@ -477,7 +476,7 @@ GameConfig::~GameConfig() = default;
 
 void GameConfig::loadConfig() {
 
-  ScriptManager::loadConfigFile(luaconfigfile, "config", this->usePhysFS);
+  ScriptManager::loadConfigFile(luaconfigfile, "config");
 
   if (player_name->length() == 0) {
     std::stringstream default_player;
@@ -527,8 +526,8 @@ void GameConfig::saveConfig() {
     return;
   }
 
-  const char* path = usePhysFS ? filesystem::getRealName(luaconfigfile.c_str()).c_str() : luaconfigfile.c_str();
-  LOGGER.warning("Writing config to: %s from %s. usePhysFS=%d", path, luaconfigfile.c_str(), usePhysFS);
+  const char* path = luaconfigfile.c_str();
+  LOGGER.warning("Writing config to %s ", path);
   OFileStream out(path);
   out << lua_tostring(L, -1) << std::endl;
   lua_pop(L, 1);

--- a/src/NetPanzer/Interfaces/GameConfig.cpp
+++ b/src/NetPanzer/Interfaces/GameConfig.cpp
@@ -527,7 +527,9 @@ void GameConfig::saveConfig() {
     return;
   }
 
-  OFileStream out(usePhysFS ? filesystem::getRealName(luaconfigfile.c_str()).c_str() : luaconfigfile.c_str());
+  const char* path = usePhysFS ? filesystem::getRealName(luaconfigfile.c_str()).c_str() : luaconfigfile.c_str();
+  LOGGER.info("Writing config to: %s", path);
+  OFileStream out(path);
   out << lua_tostring(L, -1) << std::endl;
   lua_pop(L, 1);
   LOGGER.info("Config saved.");

--- a/src/NetPanzer/Interfaces/GameConfig.cpp
+++ b/src/NetPanzer/Interfaces/GameConfig.cpp
@@ -528,7 +528,7 @@ void GameConfig::saveConfig() {
   }
 
   const char* path = usePhysFS ? filesystem::getRealName(luaconfigfile.c_str()).c_str() : luaconfigfile.c_str();
-  LOGGER.info("Writing config to: %s from %s. usePhysFS=%d", path, luaconfigfile.c_str(), usePhysFS);
+  LOGGER.warning("Writing config to: %s from %s. usePhysFS=%d", path, luaconfigfile.c_str(), usePhysFS);
   OFileStream out(path);
   out << lua_tostring(L, -1) << std::endl;
   lua_pop(L, 1);

--- a/src/NetPanzer/Interfaces/GameConfig.cpp
+++ b/src/NetPanzer/Interfaces/GameConfig.cpp
@@ -528,7 +528,7 @@ void GameConfig::saveConfig() {
   }
 
   const char* path = usePhysFS ? filesystem::getRealName(luaconfigfile.c_str()).c_str() : luaconfigfile.c_str();
-  LOGGER.info("Writing config to: %s", path);
+  LOGGER.info("Writing config to: %s from %s. usePhysFS=%d", path, luaconfigfile.c_str(), usePhysFS);
   OFileStream out(path);
   out << lua_tostring(L, -1) << std::endl;
   lua_pop(L, 1);

--- a/src/NetPanzer/Interfaces/GameConfig.hpp
+++ b/src/NetPanzer/Interfaces/GameConfig.hpp
@@ -116,7 +116,7 @@ class Section;
 
 class GameConfig : public NoCopy {
  public:
-  GameConfig(const std::string& luaconfigfile, bool usePhysFS = true);
+  GameConfig(const std::string& luaconfigfile);
   ~GameConfig();
 
   void loadConfig();
@@ -328,7 +328,6 @@ class GameConfig : public NoCopy {
   static void registerScript(const NPString& table_name);
 
   std::string luaconfigfile;
-  bool usePhysFS;
 
   PIX colorEnumToPix(int color_enum) const {
     switch (color_enum) {

--- a/src/NetPanzer/Interfaces/MenuConfig.cpp
+++ b/src/NetPanzer/Interfaces/MenuConfig.cpp
@@ -103,7 +103,7 @@ static const ScriptVarBindRecord button_setters[] = {
 };
 
 void MenuConfig::loadConfig() {
-  ScriptManager::loadConfigFile(luaconfigfile, "menu", true);
+  ScriptManager::loadConfigFile(luaconfigfile, "menu");
 }
 
 void MenuConfig::registerScript(const NPString& table_name) {

--- a/src/NetPanzer/Scripts/ScriptManager.cpp
+++ b/src/NetPanzer/Scripts/ScriptManager.cpp
@@ -306,9 +306,9 @@ void ScriptManager::runFileInTable(const NPString& filename,
 
 void ScriptManager::loadConfigFile(const NPString& filename,
                                    const NPString& table, const bool usePhysFS) {
-  int r =
-    luaL_loadfile(luavm,
-      usePhysFS ? filesystem::getRealName(filename.c_str()).c_str() : filename.c_str());
+  const char* path = usePhysFS ? filesystem::getRealName(filename.c_str()).c_str() : filename.c_str();
+  LOGGER.info("Reading config %s", path);
+  int r = luaL_loadfile(luavm,path);
 
   if (r) {
     LOGGER.warning("Error in loadConfigFile: %s\n", lua_tostring(luavm, -1));

--- a/src/NetPanzer/Scripts/ScriptManager.cpp
+++ b/src/NetPanzer/Scripts/ScriptManager.cpp
@@ -306,6 +306,7 @@ void ScriptManager::runFileInTable(const NPString& filename,
 
 void ScriptManager::loadConfigFile(const NPString& filename,
                                    const NPString& table) {
+  LOGGER.info("BEGIN loadConfigFile %s", filename.c_str());
   const char* path = filesystem::getRealName(filename.c_str()).c_str();
   LOGGER.info("Reading config from %s", path);
   int r = luaL_loadfile(luavm,path);

--- a/src/NetPanzer/Scripts/ScriptManager.cpp
+++ b/src/NetPanzer/Scripts/ScriptManager.cpp
@@ -307,7 +307,7 @@ void ScriptManager::runFileInTable(const NPString& filename,
 void ScriptManager::loadConfigFile(const NPString& filename,
                                    const NPString& table, const bool usePhysFS) {
   const char* path = usePhysFS ? filesystem::getRealName(filename.c_str()).c_str() : filename.c_str();
-  LOGGER.info("Reading config %s", path);
+  LOGGER.info("Reading config %s from name %s. usePhysFS=%d", path, filename.c_str(), usePhysFS);
   int r = luaL_loadfile(luavm,path);
 
   if (r) {

--- a/src/NetPanzer/Scripts/ScriptManager.cpp
+++ b/src/NetPanzer/Scripts/ScriptManager.cpp
@@ -305,9 +305,9 @@ void ScriptManager::runFileInTable(const NPString& filename,
 }
 
 void ScriptManager::loadConfigFile(const NPString& filename,
-                                   const NPString& table, const bool usePhysFS) {
-  const char* path = usePhysFS ? filesystem::getRealName(filename.c_str()).c_str() : filename.c_str();
-  LOGGER.warning("Reading config %s from name %s. usePhysFS=%d", path, filename.c_str(), usePhysFS);
+                                   const NPString& table) {
+  const char* path = filename.c_str();
+  LOGGER.info("Reading config from %s", path);
   int r = luaL_loadfile(luavm,path);
 
   if (r) {

--- a/src/NetPanzer/Scripts/ScriptManager.cpp
+++ b/src/NetPanzer/Scripts/ScriptManager.cpp
@@ -307,9 +307,9 @@ void ScriptManager::runFileInTable(const NPString& filename,
 void ScriptManager::loadConfigFile(const NPString& filename,
                                    const NPString& table) {
   LOGGER.info("BEGIN loadConfigFile %s", filename.c_str());
-  const char* path = filesystem::getRealName(filename.c_str()).c_str();
-  LOGGER.info("Reading config from %s", path);
-  int r = luaL_loadfile(luavm,path);
+  const std::string path = filesystem::getRealName(filename.c_str());
+  LOGGER.info("Reading config from %s", path.c_str());
+  int r = luaL_loadfile(luavm, path.c_str());
 
   if (r) {
     LOGGER.warning("Error in loadConfigFile: %s\n", lua_tostring(luavm, -1));

--- a/src/NetPanzer/Scripts/ScriptManager.cpp
+++ b/src/NetPanzer/Scripts/ScriptManager.cpp
@@ -306,7 +306,7 @@ void ScriptManager::runFileInTable(const NPString& filename,
 
 void ScriptManager::loadConfigFile(const NPString& filename,
                                    const NPString& table) {
-  const char* path = filename.c_str();
+  const char* path = filesystem::getRealName(filename.c_str()).c_str();
   LOGGER.info("Reading config from %s", path);
   int r = luaL_loadfile(luavm,path);
 

--- a/src/NetPanzer/Scripts/ScriptManager.cpp
+++ b/src/NetPanzer/Scripts/ScriptManager.cpp
@@ -307,7 +307,7 @@ void ScriptManager::runFileInTable(const NPString& filename,
 void ScriptManager::loadConfigFile(const NPString& filename,
                                    const NPString& table, const bool usePhysFS) {
   const char* path = usePhysFS ? filesystem::getRealName(filename.c_str()).c_str() : filename.c_str();
-  LOGGER.info("Reading config %s from name %s. usePhysFS=%d", path, filename.c_str(), usePhysFS);
+  LOGGER.warning("Reading config %s from name %s. usePhysFS=%d", path, filename.c_str(), usePhysFS);
   int r = luaL_loadfile(luavm,path);
 
   if (r) {

--- a/src/NetPanzer/Scripts/ScriptManager.hpp
+++ b/src/NetPanzer/Scripts/ScriptManager.hpp
@@ -44,7 +44,6 @@ class ScriptManager {
 
   static void runFileInTable(const NPString& filename, const NPString& table);
   static void loadConfigFile(const NPString& filename, const NPString& table);
-  static void loadConfigFile(const NPString& filename, const NPString& table, const bool usePhysFS = false);
   static bool loadSimpleConfig(const NPString& filename);
 
   static lua_State* getLuavm() { return luavm; }


### PR DESCRIPTION
Fixes https://github.com/netpanzer/netpanzer/issues/264

I think differentiating between using physfs or not is a bad idea. We should just always use paths relative to physfs.

Also fixes default log level to be INFO, I have always wondered why info logs don't work :)
