### PR TITLE
Disable SDL2 subproject test build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -110,7 +110,7 @@ if not sdl2_dep.found()
       version: '>=2.0.18',
       required: true,
       fallback: 'sdl2',
-      default_options: 'default_library=static')
+      default_options: ['default_library=static', 'test=false'])
   endif
 endif
 deps += sdl2_dep


### PR DESCRIPTION
## Summary

The SDL2 meson wrap builds ~65 test/demo executables (`testautomation`, `testwm2`, `testvulkan`, `testsprite2`, etc.) by default. With the project's default debug + sanitizer settings each one is statically linked against SDL2 and weighs ~40 MB, so a full build leaves **~2.6 GB** of unrelated artifacts in `_build/subprojects/SDL2-2.28.5/test/`.

This passes `test=false` through the SDL2 subproject's `default_options` so the wrap skips building them. NetPanzer doesn't depend on any of those binaries.

After this change a fresh build of this repo drops from **3.8 GB → 1.3 GB** on disk.

## Test plan

- [x] `rm -rf _build && ./setup-build.sh _build && ninja -C _build` produces a working `netpanzer` binary
- [x] `_build/subprojects/SDL2-2.28.5/test/` is no longer populated with test executables
- [x] Existing build dirs can adopt the change with `meson configure _build -Dsdl2:test=false`