### PR TITLE
Move AppImage build to v3-jammy and drop arm/v7

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -16,21 +16,20 @@ on:
     branches: master
     paths:
     - '**/appimage.yml'
-    - '**/AppRun'
-    - '**/make-appimage.sh'
+    - 'support/appimage/**'
 
 env:
   VERSION: ${{ inputs.version }}
 
 jobs:
   build-appimage:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
-          - linux/arm/v7
+        os:
+          - ubuntu-24.04        # native amd64
+          - ubuntu-24.04-arm    # native arm64
     steps:
     - name: Set version
       run: |
@@ -43,20 +42,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - if: ${{ ! contains(matrix.platform, 'amd64') }}
-      uses: docker/setup-qemu-action@v3
-
     - name: Build AppImage
-      run: |
-        docker run -t \
-        --platform=${{ matrix.platform }} \
-        --rm \
-        -e HOSTUID=$(id -u) \
-        -e VERSION \
-        -v $GITHUB_WORKSPACE:/workspace \
-        -w /workspace andy5995/linuxdeploy:v2-focal support/appimage/make-appimage.sh
-        # Docs for this container are at
-        # https://github.com/andy5995/linuxdeploy-build-helper-container
+      # Container docs: https://github.com/andy5995/linuxdeploy-build-helper-container
+      run: docker compose -f support/appimage/docker-compose.yml run --rm build
 
     - name: Create sha256sum
       run: |
@@ -80,7 +68,9 @@ jobs:
         omitBodyDuringUpdate: true
         omitNameDuringUpdate: true
         tag: appimage-weekly
-        removeArtifacts: ${{ matrix.platform == 'linux/amd64' }}
+        # Only the amd64 job clears stale artifacts so the arm64 job's
+        # upload isn't deleted afterwards.
+        removeArtifacts: ${{ matrix.os == 'ubuntu-24.04' }}
 
     - if: ${{ github.ref != 'refs/heads/master' }}
       name: Upload AppImage

--- a/support/appimage/.env.example
+++ b/support/appimage/.env.example
@@ -1,0 +1,10 @@
+# Copy this file to .env (alongside docker-compose.yml) and adjust.
+#
+# HOSTUID/HOSTGID are auto-detected by v3-jammy from the bind-mounted
+# workspace owner. Uncomment to override (e.g. when workspace ownership
+# doesn't match the invoking user).
+#HOSTUID=
+#HOSTGID=
+
+# Version string used in the AppImage filename.
+VERSION=

--- a/support/appimage/docker-compose.yml
+++ b/support/appimage/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  build:
+    environment:
+      # HOSTUID/HOSTGID are auto-detected by v3-jammy from the
+      # bind-mounted workspace owner; export them only to override.
+      HOSTUID: ${HOSTUID}
+      HOSTGID: ${HOSTGID}
+      VERSION: ${VERSION}
+    image: andy5995/linuxdeploy:v3-jammy
+    volumes:
+      - ../../:/workspace
+    working_dir: /workspace
+    command: "${SCRIPT:-support/appimage/make-appimage.sh}"


### PR DESCRIPTION
> This commit message was drafted by Claude, an LLM made by Anthropic,
> and committed at the direction of @andy5995.

The andy5995/linuxdeploy image publishes amd64 + arm64 manifests only; arm/v7 has no matching layer, so qemu emulation cannot bridge the gap. Modern ARM users are predominantly arm64 (Pi 4+, Apple Silicon, modern Android/Chromebook); arm/v7 is the Pi 1/2/3 long tail where an RTS would likely be CPU-limited regardless. Source builds via support/cross/ remain available for that case.

Native arm64 runners (ubuntu-24.04-arm) replace qemu emulation, and v3-jammy auto-detects HOSTUID/HOSTGID — so docker/setup-qemu-action, the HOSTUID export, and the PLATFORM passthrough all fall out.