### PR TITLE
Fix container-overflow when deleting all particles

### DIFF
--- a/src/NetPanzer/Particles/Particle2D.cpp
+++ b/src/NetPanzer/Particles/Particle2D.cpp
@@ -17,6 +17,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 //---------------------------------------------------------------------------
 
+#ifndef TEST_LIB
+
 #include "Particles/Particle2D.hpp"
 
 #include "2D/PackedSurface.hpp"
@@ -108,11 +110,14 @@ void Particle2D::removeMe() {
 // removeAll
 //---------------------------------------------------------------------------
 void Particle2D::removeAll() {
-  // Delete all particles in the vector
-  for (Particle2D* particle : particles) {
-    delete particle;
+  // ~Particle2D() calls removeMe(), which mutates 'particles' via swap-and-pop.
+  // Iterating the vector while it shrinks reads past the end (AddressSanitizer
+  // reports a container-overflow) and skips the particles that get swapped down
+  // into slots the loop has already passed, leaking them. Always delete the
+  // last element instead; removeMe() then only has to pop_back().
+  while (!particles.empty()) {
+    delete particles.back();
   }
-  particles.clear();
 }  // end Particle2D::removeAll
 
 // simAll
@@ -128,8 +133,12 @@ void Particle2D::simAll() {
 // drawAll
 //---------------------------------------------------------------------------
 void Particle2D::drawAll(const Surface &clientArea, SpriteSorter &sorter) {
-  // Iterate through all particles in the vector
-  for (Particle2D* particle : particles) {
+  // draw() can delete the particle (see SparkParticle2D::draw), so this has the
+  // same constraint as simAll(): iterate backwards by index. The element that
+  // swap-and-pop moves is always one this loop has already visited, and new
+  // particles are appended past the current index.
+  for (size_t i = particles.size(); i > 0; --i) {
+    Particle2D* particle = particles[i - 1];
     particle->draw(clientArea, sorter);
   }
 }  // end Particle2D::drawAll
@@ -246,3 +255,48 @@ int Particle2D::getFarAway(const fXYZ &worldPos) {
   // The particle must be near the screen.
   return 0;
 }  // end Particle2D::getFarAway
+
+#else
+
+#include "Particles/Particle2D.hpp"
+#include "test.hpp"
+
+// Deleting a particle removes it from the vector that removeAll() walks, so
+// removeAll() has to tolerate the container changing underneath it. Getting
+// this wrong reads past the end of the vector, which aborts under
+// AddressSanitizer, and leaves particles behind. See issue #286.
+void testRemoveAllDeletesEveryParticle(void) {
+  const int count = 8;
+
+  for (int i = 0; i < count; i++) {
+    // Each particle adds itself to the static list, which owns it from here.
+    Particle2D *particle = new Particle2D(fXYZ(float(i), 0.0f, 0.0f));
+    (void)particle;
+  }
+  assert(Particle2D::getFrameCount() == count);
+
+  Particle2D::removeAll();
+  assert(Particle2D::getFrameCount() == 0);
+
+  // The list has to stay usable afterwards.
+  Particle2D *particle = new Particle2D(fXYZ(0.0f, 0.0f, 0.0f));
+  (void)particle;
+  assert(Particle2D::getFrameCount() == 1);
+
+  Particle2D::removeAll();
+  assert(Particle2D::getFrameCount() == 0);
+
+  return;
+}
+
+// main() must be defined with the args in this format, otherwise we may get an
+// "undefined reference to SDL_main"
+int main(int argc, char *argv[]) {
+  (void)argc;
+  (void)argv;
+
+  testRemoveAllDeletesEveryParticle();
+  return 0;
+}
+
+#endif

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,7 +1,8 @@
 test_cases = [
   '../src/Lib/package',
   '../src/Lib/2D/CachedFontRenderer',
-  '../src/Lib/Util/FileSystem'
+  '../src/Lib/Util/FileSystem',
+  '../src/NetPanzer/Particles/Particle2D'
   ]
 
 fs = import('fs')


### PR DESCRIPTION
Fixes #286.

## The cause

`7b5cd54` replaced `Particle2D`'s intrusive linked list with a `std::vector<Particle2D*>` and made `removeMe()` remove by swap-and-pop. Two of the static loops over that vector were left as range-for loops, and both can delete elements while iterating.

`removeAll()` is the one that aborts. `delete particle` runs `~Particle2D()`, which calls `removeMe()`, which calls `pop_back()`. The range-for's end iterator was computed before the first deletion, so as soon as the vector shrinks the loop is reading past the new `size()` — the region libc++'s container annotations have poisoned, which is exactly what AddressSanitizer reports. On top of the out-of-bounds read, swap-and-pop moves the last element down into the slot the loop has just left, so those particles are never visited and leak.

Because `meson.build` defaults to `b_sanitize=address,undefined`, this aborts an ordinary development build on quitting a game:

```
==96924==ERROR: AddressSanitizer: container-overflow on address 0x61900017bd20
READ of size 8 at 0x61900017bd20 thread T0
    #0 Particle2D::removeAll() Particle2D.cpp:112
    #1 GameManager::quitNetPanzerGame() GameManager.cpp:775
    #2 GameManager::exitNetPanzer() GameManager.cpp:755
    #3 PlayerGameManager::mainLoop() PlayerGameManager.cpp:459
```

`drawAll()` has the same defect in form, but it is **latent, not live** — I want to be clear about that rather than claim two fixed crashes. `SparkParticle2D::draw()` is the only `draw()` in the tree that does `delete this`, and `SparkParticle2D` is never constructed: the call site at `VectorPuffParticle2D.cpp:79` is commented out, and so is `SparkParticle2D::init()` at `ParticleInterface.cpp:943`. So no gameplay can currently shrink the vector during a draw pass. The change is there so that re-enabling sparks, or adding any other `draw()` that deletes, does not silently reintroduce the same out-of-bounds read. Drop it if you would rather keep this PR to the one reachable bug.

Two loops that look similar are **not** affected, and I left them alone:

- `simAll()` already iterates backwards by index. Deletion there is always a plain `pop_back()`, since the element being processed is the last one.
- `ParticleSystem2D::removeAll()` still uses the linked list and caches `next` before `delete`.

## The change

- `removeAll()`: delete the *last* element until the vector is empty. `removeMe()` then only has to `pop_back()`, so the container never reshapes in a way the loop has to track. Drops the now-redundant `particles.clear()`, and `frameCount` still lands on 0 through `removeMe()`.
- `drawAll()`: iterate backwards by index, matching `simAll()`. The element that swap-and-pop relocates is always one the loop has already visited, and particles created during a draw pass are appended past the current index. Draw order into `SpriteSorter` is not meaningfully affected — `sortLists()` buckets by height and then `std::sort`s, which is not stable, so order among equal keys was never defined.
- Adds a regression test, using the existing in-source `TEST_LIB` convention from `tests/README.md`: create several particles, `removeAll()`, assert `getFrameCount()` returns to 0, then confirm the list is still usable. This needed wrapping `Particle2D.cpp` in the `#ifndef TEST_LIB` / `#else` structure that `package.cpp` and `FileSystem.cpp` already use.

## Testing

macOS 15 / arm64, clang 21, ASan+UBSan on (the default).

With the fix, `meson test --suite=netpanzer` is 5/5. Reverting only the `removeAll()` body and keeping the new test reproduces the original abort, at the same place and with the same signature:

```
==1032==ERROR: AddressSanitizer: container-overflow on address 0x6060000016c0
READ of size 8 at 0x6060000016c0 thread T0
    #0 Particle2D::removeAll() Particle2D.cpp:118
    #1 testRemoveAllDeletesEveryParticle() Particle2D.cpp:279
    #2 main Particle2D.cpp:299
```

The `drawAll()` half is not covered by a test and cannot be, without either re-enabling `SparkParticle2D` or adding a test-only subclass whose `draw()` deletes itself. As described above, that path is unreachable today, so it is hardening rather than a reproduced crash.

Note that the tests only see `NETPANZER_DATADIR` through `meson devenv`, so run them as `meson devenv -C _build meson test --suite=netpanzer`.
