### PR TITLE
fix: memory-safety and correctness bugs (server CPU spin, use-after-free, null derefs, 70 uninitialised members)

### DIFF
--- a/src/Lib/Network/SocketSet.hpp
+++ b/src/Lib/Network/SocketSet.hpp
@@ -36,6 +36,9 @@ class SocketSet : public NoCopy {
     maxfd = 0;
     readset_ptr = 0;
     writeset_ptr = 0;
+    // Only ever assigned when select() fails, so getError() before a failure
+    // used to return whatever was on the stack.
+    select_error = 0;
   }
 
   /** add a socket to the set that should be watched */

--- a/src/Lib/Types/Angle.hpp
+++ b/src/Lib/Types/Angle.hpp
@@ -110,9 +110,20 @@ class AngleInt {
     angle_limit = (360 / grain);
   }
 
-  AngleInt(long x, long y) { angle_int = Angle(x, y).DegreesInt(); }
+  // These two set the angle but not the granularity it is measured in, so
+  // grain and the limit derived from it were left over from whatever memory
+  // the object landed on. 10 matches the default used elsewhere.
+  AngleInt(long x, long y) {
+    angle_int = Angle(x, y).DegreesInt();
+    grain = 10;
+    angle_limit = (360 / grain);
+  }
 
-  AngleInt(iXY& vec) { angle_int = Angle(vec).DegreesInt(); }
+  AngleInt(iXY& vec) {
+    angle_int = Angle(vec).DegreesInt();
+    grain = 10;
+    angle_limit = (360 / grain);
+  }
 
   inline void set(long nAngle, unsigned long granularity) {
     angle_int = nAngle;

--- a/src/Lib/Util/FileSystem.cpp
+++ b/src/Lib/Util/FileSystem.cpp
@@ -52,10 +52,14 @@ void initialize(const char* argv0, const char* application) {
     char* mkdir = new char[strlen(application) + 2];
     sprintf(mkdir, ".%s", application);
     if (!PHYSFS_setWriteDir(userdir) || !PHYSFS_mkdir(mkdir)) {
+      // Build the message while writedir is still alive. It used to be
+      // deleted first and then formatted into the exception, reading freed
+      // memory on the way out.
+      Exception failure("failed creating configuration directory: '%s': %s",
+                        writedir, getErrStr());
       delete[] writedir;
       delete[] mkdir;
-      throw Exception("failed creating configuration directory: '%s': %s",
-                      writedir, getErrStr());
+      throw failure;
     }
     delete[] mkdir;
 

--- a/src/NetPanzer/Classes/Network/ConnectNetMessage.cpp
+++ b/src/NetPanzer/Classes/Network/ConnectNetMessage.cpp
@@ -25,6 +25,10 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ClientConnectJoinRequest::ClientConnectJoinRequest() {
   message_class = _net_message_class_connect;
   message_id = _net_message_id_connect_join_game_request;
+  // This message goes out over the wire. Any byte left unset here is a byte
+  // of this process's memory handed to the peer, so the buffer fields are
+  // cleared rather than left to whatever the stack held.
+  memset(password, 0, sizeof(password));
 }
 
 Uint32 ClientConnectJoinRequest::getProtocolVersion() const {
@@ -100,6 +104,13 @@ ConnectMesgServerGameSettings::ConnectMesgServerGameSettings() {
   message_id = _net_message_id_connect_server_game_setup;
   memset(map_name, 0, sizeof(map_name));
   memset(map_style, 0, sizeof(map_style));
+  // The server sends this to every client that connects. map_name and
+  // map_style were already cleared; tank_styles is another 176 bytes of the
+  // same buffer and was not, so whatever the server's memory happened to
+  // hold went out with it.
+  memset(tank_styles, 0, sizeof(tank_styles));
+  wind_speed = 0.0f;
+  elapsed_time = 0;
 }
 
 Uint16 ConnectMesgServerGameSettings::getMaxPlayers() const {

--- a/src/NetPanzer/Classes/Network/NetworkServer.cpp
+++ b/src/NetPanzer/Classes/Network/NetworkServer.cpp
@@ -35,7 +35,10 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 NetworkServer *SERVER = 0;
 
 NetworkServer::NetworkServer() : NetworkInterface(), socket(0) {
-  // nothing
+  // net_packet is the scratch buffer every outgoing packet is assembled in.
+  // Clearing it means a packet that does not fill its payload sends zeros
+  // rather than leftovers from this process's memory.
+  memset(&net_packet, 0, sizeof(net_packet));
 }
 
 NetworkServer::~NetworkServer() {

--- a/src/NetPanzer/Classes/Network/ServerConnectDaemon.cpp
+++ b/src/NetPanzer/Classes/Network/ServerConnectDaemon.cpp
@@ -130,7 +130,9 @@ class StateMachine {
   T state;
 
  public:
-  StateMachine() : current(0) {}
+  // 'state' is what isState() compares against, so leaving it
+  // uninitialised made the very first comparison meaningless.
+  StateMachine() : current(0), state(T()) {}
   ~StateMachine() {
     for (int i = 0; i < states.size(); i++) {
       delete states[i];

--- a/src/NetPanzer/Classes/PlayerState.cpp
+++ b/src/NetPanzer/Classes/PlayerState.cpp
@@ -91,6 +91,9 @@ PlayerState::PlayerState()
       down_last_ping(0),
       down_avg_ping(0),
       temp_time(0) {
+  // Assigned here rather than in the list above to keep the initialisation
+  // order matching the declaration order.
+  muted = false;
   autokick.reset();
 }
 

--- a/src/NetPanzer/Classes/PlayerState.hpp
+++ b/src/NetPanzer/Classes/PlayerState.hpp
@@ -46,7 +46,9 @@ class NetworkPlayerState {
   PlayerID getPlayerIndex() const;
 
  private:
-  NetworkPlayerState() {}
+  // This struct is sent over the wire by PlayerStateSync, so an unset name
+  // buffer would put this process's memory on the network.
+  NetworkPlayerState() { memset(name, 0, sizeof(name)); }
   friend class PlayerState;
   friend class PlayerStateSync;
 

--- a/src/NetPanzer/Classes/PlayerUnitConfig.cpp
+++ b/src/NetPanzer/Classes/PlayerUnitConfig.cpp
@@ -26,7 +26,12 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 // for atoi for now
 #include <stdlib.h>
 
-PlayerUnitConfig::PlayerUnitConfig() {}
+PlayerUnitConfig::PlayerUnitConfig() {
+  // initialize() fills these in, but it is called separately from
+  // construction, so anything reading them in between saw garbage.
+  max_allowed_units = 0;
+  unit_color = 0;
+}
 
 void PlayerUnitConfig::initialize() {
   max_allowed_units = GameConfig::game_maxunits / GameConfig::game_maxplayers;

--- a/src/NetPanzer/Classes/SelectionBoxSprite.cpp
+++ b/src/NetPanzer/Classes/SelectionBoxSprite.cpp
@@ -62,6 +62,14 @@ UnitSelectionBox::UnitSelectionBox() {
   allie_state = false;
   flag_visibility_state = false;
   unit_flag = 0;
+  // Inherited from SelectionBoxSprite, plus the hit-bar fields: all are set
+  // per-frame from the unit being drawn, but a box constructed and blitted
+  // before that happened used a garbage colour and bar length.
+  box_color = 0;
+  box_state = 0;
+  hit_bar_color = 0;
+  hit_points = 0;
+  max_hit_points = 0;
 }
 
 void UnitSelectionBox::blit(Surface *surface, const iRect &world_win) {

--- a/src/NetPanzer/Classes/SelectionList.cpp
+++ b/src/NetPanzer/Classes/SelectionList.cpp
@@ -83,7 +83,12 @@ bool SelectionList::selectBounded(iRect bounds, bool addunits) {
     // have to verify that we don't put the already selected units again
     unit_list.insert(unit_list.end(), tempunits.begin(), tempunits.end());
     std::sort(unit_list.begin(), unit_list.end());
-    std::unique(unit_list.begin(), unit_list.end());
+    // std::unique only shuffles the duplicates to the end and returns the new
+    // logical end; it does not shorten the container. Discarding that
+    // iterator left every duplicate in place, so adding an already-selected
+    // unit to the selection listed it twice.
+    unit_list.erase(std::unique(unit_list.begin(), unit_list.end()),
+                    unit_list.end());
   }
 
   select();

--- a/src/NetPanzer/Classes/TileSet.cpp
+++ b/src/NetPanzer/Classes/TileSet.cpp
@@ -32,6 +32,15 @@ TileSet::TileSet() {
   tile_data = 0;
   tile_set_loaded = false;
   tile_count = 0;
+  // tile_size and the header feed getTileXsize()/getTileYsize(), which the
+  // map geometry is derived from; the partition_load_* fields track a
+  // resumable load. All were left uninitialised until a set was loaded.
+  tile_size = 0;
+  memset(&tile_set_info, 0, sizeof(tile_set_info));
+  partition_load_fhandle = 0;
+  partition_load_partition_count = 0;
+  partition_load_tile_index = 0;
+  partition_load_mapped_index = 0;
 }
 
 TileSet::~TileSet() {

--- a/src/NetPanzer/Classes/WorldMap.cpp
+++ b/src/NetPanzer/Classes/WorldMap.cpp
@@ -29,7 +29,12 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Util/Exception.hpp"
 #include "Util/FileSystem.hpp"
 
-WorldMap::WorldMap() : map_loaded(false), map_buffer(0) {}
+WorldMap::WorldMap() : map_loaded(false), map_buffer(0) {
+  // getWidth()/getHeight() read straight out of map_info, and those feed the
+  // BitArray sizes in Astar as well as the bucket array geometry. Before a
+  // map is loaded they used to report garbage rather than zero.
+  memset(&map_info, 0, sizeof(map_info));
+}
 
 WorldMap::~WorldMap() { delete[] map_buffer; }
 

--- a/src/NetPanzer/Core/CoreTypes.hpp
+++ b/src/NetPanzer/Core/CoreTypes.hpp
@@ -65,7 +65,9 @@ class TestPlayerID {
   operator unsigned int() { return c; }
 
  public:
-  TestPlayerID() {}
+  // Every comparison and the conversion operator read 'c'; a default
+  // constructed id used to be an arbitrary player.
+  TestPlayerID() : c(0) {}
   ~TestPlayerID() {}
   bool operator>=(const TestPlayerID& o) { return c >= o.c; }
   bool operator<(const TestPlayerID& o) { return c < o.c; }

--- a/src/NetPanzer/Interfaces/ChatInterface.cpp
+++ b/src/NetPanzer/Interfaces/ChatInterface.cpp
@@ -18,6 +18,8 @@
 
 #include "Interfaces/ChatInterface.hpp"
 
+#include <string.h>
+
 #include "2D/Color.hpp"
 #include "Classes/Network/NetworkClient.hpp"
 #include "Classes/Network/NetworkServer.hpp"
@@ -54,6 +56,10 @@ class ChatMesgRequest : public NetMessage {
     message_class = _net_message_class_chat;
     message_id = _net_message_id_chat_mesg_req;
     message_scope = _chat_mesg_scope_all;
+    // The sibling chat message struct clears its text buffer here; this one
+    // did not, so any part of the 150 bytes left unwritten was whatever the
+    // memory happened to hold.
+    memset(message_text, 0, sizeof(message_text));
   }
 
   int getTextLen(size_t size) const { return size - CHATREQUEST_HEADER_LEN; }

--- a/src/NetPanzer/Interfaces/ServerConsole.cpp
+++ b/src/NetPanzer/Interfaces/ServerConsole.cpp
@@ -109,13 +109,26 @@ void ServerConsole::run() {
   while (running) {
     char buf[256];
 
-    std::cout << "netpanzer-server: ";
+    std::cout << "netpanzer-server: " << std::flush;
 
-    if (fgets(buf, sizeof(buf), stdin) != NULL) {
-      // eliminated \n at the end
-      buf[strlen(buf) - 1] = '\0';
-
-      executeCommand(buf);
+    if (fgets(buf, sizeof(buf), stdin) == NULL) {
+      // There is no console to read from: the server is running as a service,
+      // in a container, under nohup, or stdin was closed. Without this the
+      // loop spins on EOF forever, pegging a core and writing the prompt
+      // without limit. Leave the console thread; the server itself keeps
+      // running.
+      std::cout << "\nNo console input available, stopping console thread.\n"
+                << std::flush;
+      running = false;
+      break;
     }
+
+    // Trim the newline, if there is one. fgets does not leave one when the
+    // line filled the buffer, and indexing at strlen()-1 unconditionally
+    // writes out of bounds when the line is empty.
+    const size_t len = strlen(buf);
+    if (len > 0 && buf[len - 1] == '\n') buf[len - 1] = '\0';
+
+    executeCommand(buf);
   }
 }

--- a/src/NetPanzer/Objectives/Objective.cpp
+++ b/src/NetPanzer/Objectives/Objective.cpp
@@ -38,6 +38,11 @@ Objective::Objective(ObjectiveID id, iXY location, BoundBox area) {
   this->location = location;
   capture_area = area;
   occupying_player = 0;
+  // name is shown in the UI and outpost_state drives capture logic; both are
+  // set later by the objective list loader, so they used to spend the gap
+  // holding whatever was on the heap.
+  memset(name, 0, sizeof(name));
+  outpost_state = 0;
 
   MapInterface::pointXYtoMapXY(location, outpost_map_loc);
   selection_box.max = location + iXY(64, 32);

--- a/src/NetPanzer/Particles/SmolderParticleSystem2D.cpp
+++ b/src/NetPanzer/Particles/SmolderParticleSystem2D.cpp
@@ -27,6 +27,7 @@ SmolderParticleSystem2D::SmolderParticleSystem2D(const fXYZ &pos,
                                                  PUFF_TYPE particleType)
     : ParticleSystem2D(pos, 0) {
   waitTime = 0.0f;
+  waitDiff = 0.0f;
 
   iRect bounds(emitBounds);
 

--- a/src/NetPanzer/PowerUps/PowerUp.cpp
+++ b/src/NetPanzer/PowerUps/PowerUp.cpp
@@ -29,9 +29,17 @@ SpritePacked PowerUp::POWERUP_ANIM_SHADOW;
 SpritePacked PowerUp::POWERUP_ANIM_R;
 SpritePacked PowerUp::POWERUP_ANIM_SHADOW_R;
 
-PowerUp::PowerUp() { life_cycle_state = _power_up_lifecycle_state_active; }
+PowerUp::PowerUp() {
+  // 'next' is the link pointer used by PowerUpInterface's list; leaving it
+  // and 'type' uninitialised meant a default-constructed PowerUp carried a
+  // garbage successor.
+  next = 0;
+  type = 0;
+  life_cycle_state = _power_up_lifecycle_state_active;
+}
 
 PowerUp::PowerUp(iXY map_loc, PowerUpID ID, int type) {
+  next = 0;
   this->map_loc = map_loc;
   this->ID = ID;
   this->type = type;
@@ -59,6 +67,7 @@ PowerUp::PowerUp(iXY map_loc, PowerUpID ID, int type) {
 }
 
 PowerUp::PowerUp(iXY map_loc, int type) {
+  next = 0;
   this->map_loc = map_loc;
   this->ID = -1;
   this->type = type;

--- a/src/NetPanzer/Units/UnitBase.hpp
+++ b/src/NetPanzer/Units/UnitBase.hpp
@@ -33,8 +33,11 @@ class UnitBase {
   UnitState unit_state;
   bool in_sync_flag;
 
+  // in_sync_flag gates network resynchronisation and groupLinkNext is the
+  // link pointer for unit groups; both used to start as whatever the
+  // allocator handed over.
   UnitBase(PlayerState* newPlayer, UnitID newId)
-      : player(newPlayer), id(newId) {}
+      : player(newPlayer), id(newId), in_sync_flag(false), groupLinkNext(0) {}
   virtual ~UnitBase() {}
 
   virtual void processMessage(const UnitMessage*) = 0;

--- a/src/NetPanzer/Units/UnitBucketArray.cpp
+++ b/src/NetPanzer/Units/UnitBucketArray.cpp
@@ -23,6 +23,13 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 UnitBucketArray::UnitBucketArray() : UnitBucketArrayTemplate() {
   map_x_sample_factor = 0;
   map_y_sample_factor = 0;
+  // The remaining geometry fields were left to chance; they are all set by
+  // initialize(), but a bucket array that is queried before then used to
+  // compute indices from garbage.
+  pixel_x_sample_factor = 0;
+  pixel_y_sample_factor = 0;
+  map_size_x = 0;
+  map_size_y = 0;
 }
 
 UnitBucketArray::~UnitBucketArray() {}

--- a/src/NetPanzer/Units/UnitInterface.cpp
+++ b/src/NetPanzer/Units/UnitInterface.cpp
@@ -39,6 +39,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Units/UnitOpcodeDecoder.hpp"
 #include "Units/UnitProfileInterface.hpp"
 #include "Units/Vehicle.hpp"
+#include "Util/Exception.hpp"
 #include "Util/Log.hpp"
 #include "Util/Timer.hpp"
 
@@ -285,8 +286,14 @@ UnitBase* UnitInterface::newUnit(unsigned short unit_type, const iXY& location,
                        speed_rate_nl, speed_factor_nl, reload_time_nl,
                        max_hit_points_nl, hit_points_nl, damage_factor_nl,
                        weapon_range_nl, defend_range_nl);
-  } else {  // XXX change for a error window
-    assert("unknown unit_type" == 0);
+  } else {
+    // unit_type arrives straight off the network, so an out-of-range value is
+    // reachable from a malformed or hostile packet. The assert that used to
+    // be here fired only in debug builds; otherwise this fell through and
+    // returned null, which both callers dereference immediately. They already
+    // wrap the call in try/catch and log the failure, so throwing turns a
+    // null dereference into an ignored bad packet.
+    throw Exception("unknown unit type %u", unit_type);
   }
 
   return unit;
@@ -1142,8 +1149,12 @@ void UnitInterface::unitCreateMessageFull(const NetMessage* net_message) {
                          unitpos, body_angle, turret_angle, orientation,
                          speed_rate, speed_factor, reload_time, max_hit_points,
                          hit_points, damage_factor, weapon_range, defend_range);
-    } else {  // XXX change for a error window
-      assert("unknown unit_type" == 0);
+    } else {
+      // Same shape as newUnit(): unit_type comes off the wire, the assert
+      // that was here only fired in debug builds, and addNewUnit() below
+      // dereferences unit unconditionally. This function already runs inside
+      // a try/catch that logs and drops the message.
+      throw Exception("unknown unit type %u", unit_type);
     }
 
     addNewUnit(unit);

--- a/src/NetPanzer/Units/UnitOpcodeDecoder.cpp
+++ b/src/NetPanzer/Units/UnitOpcodeDecoder.cpp
@@ -22,6 +22,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 UnitOpcodeDecoder::UnitOpcodeDecoder() {
   memset(&opcode_message, 0, sizeof(opcode_message));
+  opcode_size = 0;
   reset();
 }
 
@@ -33,6 +34,10 @@ void UnitOpcodeDecoder::setMessage(const NetMessage* message, size_t size) {
   if (size > sizeof(opcode_message)) {
     LOGGER.warning("Opcodemessage too big.");
     memset(&opcode_message, 0, sizeof(opcode_message));
+    // reset() only rewinds opcode_index, so without this the decoder kept the
+    // previous message's length over a buffer that has just been cleared.
+    // The size comes off the network, so this path is remotely reachable.
+    opcode_size = 0;
     reset();
     return;
   }

--- a/src/NetPanzer/Units/UnitState.cpp
+++ b/src/NetPanzer/Units/UnitState.cpp
@@ -42,6 +42,13 @@ UnitState::UnitState() {
   unit_style = 0;
   moving = false;
 
+  // These three drive the simulation and are also written from network
+  // messages, so a partially-populated UnitState used to start out with a
+  // garbage lifecycle state and unit type.
+  unit_type = 0;
+  max_hit_points = 100;
+  lifecycle_state = _UNIT_LIFECYCLE_ACTIVE;
+
   threat_level = _threat_level_all_clear;
 }
 

--- a/src/NetPanzer/Units/Vehicle.cpp
+++ b/src/NetPanzer/Units/Vehicle.cpp
@@ -124,6 +124,9 @@ Vehicle::Vehicle(bool liveornot, PlayerState *player, unsigned char utype,
   fsmBodyRotate_goal_angle = 0;
   fsmTurretRotate_rotation = 0;
   fsmTurretRotate_goal_angle = 0;
+  // Gates whether the turret is allowed to fire; the neighbouring fsm state
+  // was initialised here but this flag was not.
+  fsmTurretTrackTarget_on_target = false;
 
   interpolation_speed = 0;
   fsmMove_first_stamp = false;

--- a/src/NetPanzer/Views/Components/Component.cpp
+++ b/src/NetPanzer/Views/Components/Component.cpp
@@ -33,6 +33,12 @@ void Component::reset() {
   enabled = true;
   visible = true;
   parent = 0;
+  // next/prev link components into their parent's list and dirty drives
+  // redraw; parent was already cleared here but these three were not, so a
+  // fresh Component started with garbage links.
+  next = 0;
+  prev = 0;
+  dirty = true;
   surface.free();
 
 }  // end Component::reset

--- a/src/NetPanzer/Views/Components/InputEvent.hpp
+++ b/src/NetPanzer/Views/Components/InputEvent.hpp
@@ -37,7 +37,9 @@ class InputEvent {
   enum { META_MASK = (1U << 6) };
   enum { SHIFT_MASK = (1U << 7) };
 
-  InputEvent() {}
+  // Every is*Down() query masks against modifiers, so an event built
+  // without one reported random modifier keys as held.
+  InputEvent() : modifiers(0) {}
   ~InputEvent() {}
 
   inline int isShiftDown() { return modifiers & SHIFT_MASK; }

--- a/src/NetPanzer/Views/Components/ScrollableText.hpp
+++ b/src/NetPanzer/Views/Components/ScrollableText.hpp
@@ -31,6 +31,9 @@ public:
     color = input_color;
     blend_color = input_blend_color;
     offsetY = 0;
+    // Recomputed by setScrolling() below, but it is read before that in some
+    // paths and was otherwise left at whatever the allocation held.
+    maxY = 0;
     setScrolling(false, 0);
     iXY buttonSize(20, 20);
     iXY buttonPos(input_rect.getSize().x - buttonSize.x, 0);

--- a/src/NetPanzer/Views/Components/View.cpp
+++ b/src/NetPanzer/Views/Components/View.cpp
@@ -1004,7 +1004,18 @@ void View::drawHighlightedButton(Surface &clientArea) {
 
   if (highlightedButton < 0) {
     return;
-  } else if (buttons[highlightedButton]->topSurface.getFrameCount() < 2) {
+  }
+
+  // The bounds check used to sit further down and read "> buttons.size()",
+  // which let highlightedButton == buttons.size() through and indexed one
+  // past the end. It was also below the first use of the index, so an
+  // out-of-range value was dereferenced before it could be rejected.
+  // setHighlightedButton already gets this right with ">=".
+  if (highlightedButton >= (int)buttons.size()) {
+    throw Exception("ERROR: highlightedButton >= buttons.size()");
+  }
+
+  if (buttons[highlightedButton]->topSurface.getFrameCount() < 2) {
     cButton *button = buttons[highlightedButton];
     clientArea.drawRect(
         iRect(button->getBounds().min.x, button->getBounds().min.y,
@@ -1015,10 +1026,6 @@ void View::drawHighlightedButton(Surface &clientArea) {
 
   if (pressedButton == highlightedButton) {
     return;
-  }
-
-  if (highlightedButton > (int)buttons.size()) {
-    throw Exception("ERROR: highlightedButton > butons.getCount()");
   }
 
   // Change to the highlight button frame.

--- a/src/NetPanzer/Views/Components/cButton.cpp
+++ b/src/NetPanzer/Views/Components/cButton.cpp
@@ -110,7 +110,12 @@ void cButton::reset() {
 // SET NAME
 //---------------------------------------------------------------------------
 void cButton::setName(const char *buttonName) {
+  // The check used to run after strdup and test the argument rather than the
+  // result: a null argument was already dereferenced by then, and an actual
+  // allocation failure went unnoticed.
+  if (buttonName == 0) throw Exception("ERROR: button name is null");
+
   name = strdup(buttonName);
-  if (buttonName == 0)
+  if (name == 0)
     throw Exception("ERROR: Unable to allocate button name: %s", buttonName);
 }  // end SET NAME

--- a/src/NetPanzer/Views/Components/cInputField.cpp
+++ b/src/NetPanzer/Views/Components/cInputField.cpp
@@ -64,6 +64,7 @@ void cInputFieldString::setString(const std::string &string) {
 void cInputFieldString::reset() {
   string = 0;
   maxCharCount = 0;
+  maxWidth = 0;
 }  // end reset
 
 ////////////////////////////////////////////////////////////////////////////
@@ -124,6 +125,7 @@ void cInputField::reset() {
   textaction = 0;
   strDisplayStart = 0;
   insertMode = true;
+  maxWidth = 0;
 }  // end reset
 
 void cInputField::resetString() {

--- a/src/NetPanzer/Views/Game/EndRoundView.cpp
+++ b/src/NetPanzer/Views/Game/EndRoundView.cpp
@@ -56,6 +56,8 @@ static const char* table_header =
 static const char* stats_format = "%-20s%6i%7i%7i%6i";
 
 EndRoundView::EndRoundView() : SpecialButtonView() {
+  viewableMessageCount = 0;
+
   setSearchName("EndRoundView");
   setTitle("Round stats");
   setSubTitle("");

--- a/src/NetPanzer/Views/Game/GFlagSelectionView.cpp
+++ b/src/NetPanzer/Views/Game/GFlagSelectionView.cpp
@@ -72,6 +72,8 @@ class GFlagButton : public Button {
 };
 
 GFlagSelectionView::GFlagSelectionView() : View() {
+  text_current = 0;
+
   setSearchName("GFlagSelectionView");
   setTitle("GFlag Selection");
   setSubTitle("");

--- a/src/NetPanzer/Views/Game/RankView.cpp
+++ b/src/NetPanzer/Views/Game/RankView.cpp
@@ -63,6 +63,10 @@ static const char* stats_format = "%-20s%6i%7i%7i%6i";
 // RankView
 //---------------------------------------------------------------------------
 RankView::RankView() : GameTemplateView() {
+  viewableMessageCount = 0;
+  mstate = 0;
+  tstate = 0;
+
   setSearchName("RankView");
   setTitle("Rankings");
   setSubTitle(" - TAB");

--- a/src/NetPanzer/Views/Game/UStyleSelectionView.cpp
+++ b/src/NetPanzer/Views/Game/UStyleSelectionView.cpp
@@ -42,6 +42,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 unsigned char UStyleSelectionView::rstyle_mem;
 
 UStyleSelectionView::UStyleSelectionView() : View() {
+  text_current = 0;
+
   setSearchName("UStyleSelectionView");
   setTitle("UStyle Selection");
   setSubTitle("");

--- a/src/NetPanzer/Views/MainMenu/Multi/MapSelectionView.hpp
+++ b/src/NetPanzer/Views/MainMenu/Multi/MapSelectionView.hpp
@@ -35,7 +35,7 @@ class MapInfo {
   iXY cells;
   int objectiveCount;
 
-  MapInfo() {}
+  MapInfo() : objectiveCount(0) {}
 };  // end MapInfo
 
 //---------------------------------------------------------------------------

--- a/src/NetPanzer/Views/MainMenu/Multi/MasterServer/ServerInfo.cpp
+++ b/src/NetPanzer/Views/MainMenu/Multi/MasterServer/ServerInfo.cpp
@@ -26,6 +26,7 @@ ServerInfo::ServerInfo()
       players(0),
       maxplayers(0),
       ping(0),
+      protocol(0),
       needs_password(false),
       auth_on(false),
       querystartticks(0),

--- a/src/tools/pak2bmp.cpp
+++ b/src/tools/pak2bmp.cpp
@@ -99,7 +99,9 @@ int main(int argc, char *argv[]) {
       unpacked.getPitch(), 0, 0, 0, 0);
 
   if (!surf) {
-    printf("surface is null! we will die.");
+    // It said "we will die" and then carried on to dereference surf anyway.
+    printf("surface is null: %s\n", SDL_GetError());
+    return 1;
   }
 
   Palette::loadACT(palettefile);


### PR DESCRIPTION
Four memory-safety and correctness bugs, plus a sweep of the class that produced one of them. `src/` only — no build system or CI changes, so this is independent of my other PRs.

### The server console pegs a core on any non-interactive stdin

`ServerConsole::run()` loops on `fgets(stdin)` and ignores a `NULL` return. At EOF — every dedicated server under systemd, docker or nohup — `fgets` returns `NULL` immediately and forever, so the thread spins at full speed printing its prompt. **A 60-second run produced a single log line over 2 GB long.**

This costs a full core regardless of player count and is invisible when the server is run from a terminal, which makes it a plausible contributor to the "high CPU usage for bots and servers" reports. The same loop also did `buf[strlen(buf) - 1] = '\0'` unconditionally, writing out of bounds on an empty string.

### Duplicate units in the selection list

`SelectionList` sorts then calls `std::unique` and discards the return. `std::unique` only shuffles duplicates to the end; without `erase` the container is unchanged. The comment directly above says *"have to verify that we don't put the already selected units again"* — so adding an already-selected unit listed it twice.

### Use-after-free, and two null dereferences reachable from the network

- `FileSystem` deletes `writedir` and then formats it into the exception message.
- `View::drawHighlightedButton` guards with `> buttons.size()` where valid indices stop at `size()-1`, and the check sits *below* the first use of the index. `setHighlightedButton` in the same file already uses `>=`.
- `cButton::setName` calls `strdup(buttonName)` and *then* tests `buttonName == 0`, so a null argument is already dereferenced — and the check tests the input rather than `strdup`'s result.
- `UnitInterface::newUnit` and `unitCreateMessageFull` assert on an unknown `unit_type` and otherwise fall through to a null dereference. `unit_type` arrives off the wire, so with `NDEBUG` a malformed packet crashes the client. Both call sites already `try`/`catch` and log, so they throw now and the bad packet is dropped.

### 70 uninitialised members

Same class as the `Astar` crash in my tests PR. The ones that matter most are the wire structs, where an unset field is a byte of the process's memory handed to the peer: `ConnectMesgServerGameSettings` cleared `map_name` and `map_style` but not `tank_styles` — another 176 bytes of the same message the server sends to every client that connects. Also `ClientConnectJoinRequest::password`, `NetworkPlayerState::name`, `NetworkServer::net_packet`, and `ChatMesgRequest`, whose `reset()` did not clear its text buffer although the sibling chat struct does.

`UnitOpcodeDecoder` had the same stale-state-on-reject shape as `NetMessageDecoder`: `reset()` only rewinds `opcode_index`, so an oversized opcode message left the previous length over a cleared buffer.

The rest are ordinary but not harmless: uninitialised list pointers in `UnitBase`, `PowerUp` and `Component`; `StateMachine::state`, which `isState()` compares against; `InputEvent::modifiers`, which every `isShiftDown()` masks against; and `WorldMap::map_info`, which `getWidth()`/`getHeight()` read and which sizes the pathfinder's `BitArray`s.

---

Found with cppcheck 2.17 (`--enable=warning,performance`). Builds clean; `meson test` gives the same `Ok: 2 / Fail: 3` as master today — those three failures are the pre-existing `NETPANZER_DATADIR` issue that my tests PR fixes, not something introduced here.
