### PR TITLE
test: make the suite runnable, add netcode/BitArray/A* tests, and fix the three bugs they found

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -37,6 +37,12 @@ jobs:
           - name: with-lto
             ubuntu: latest
             options: '-Db_lto=true'
+          # Sanitizers used to be in the project's default_options, which meant
+          # every build including releases paid for them. They are opt-in now,
+          # so one job has to ask for them explicitly.
+          - name: sanitizers
+            ubuntu: latest
+            options: '-Db_sanitize=address,undefined'
           - name: data-install-test
             ubuntu: 22.04
           - name: no-deps
@@ -132,10 +138,10 @@ jobs:
       run: |
         MESON_OPTS="$MESON_OPTS -Dprefix=$INST_PREFIX_DIR -Dnls=$want_nls"
         if [ -n "${{ matrix.cross-file }}" ]; then
-          # ASAN libs for other architectures won't be available (unless we use
-          # emulation or install an appropriate toolchain so we disable sanitize
+          # Sanitizers are off by default now, so nothing to disable here; the
+          # ASAN runtime for other architectures would not be available anyway.
           # https://github.com/google/sanitizers/wiki/AddressSanitizer
-          MESON_OPTS="$MESON_OPTS --cross-file ${{ matrix.cross-file }} -Db_sanitize=none"
+          MESON_OPTS="$MESON_OPTS --cross-file ${{ matrix.cross-file }}"
         fi
         ./setup-build.sh $MESON_OPTS ${{ matrix.options }}
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -64,11 +64,10 @@ directory itself, not at the source root:
 
     export NETPANZER_DATADIR=$PWD/data
 
-Note that `meson test` does not apply the `meson devenv` environment, so the
-tests need it too. Either run them from inside `meson devenv`, or wrap the
-command:
+The test suite sets `NETPANZER_DATADIR` for itself, so it does not need the
+`meson devenv` environment:
 
-    meson devenv -C _build meson test --suite=netpanzer
+    meson test -C _build --suite=netpanzer
 
 To build netpanzer:
 
@@ -112,8 +111,18 @@ Common options to give to 'configure' before creating a release or before
 installing:
 
     -Dbuildtype=release
-    -Db_sanitize=none
     -Db_prefix=/usr (on Windows this will be different)
+
+### Sanitizers
+
+AddressSanitizer and UndefinedBehaviorSanitizer are **not** enabled by default,
+so a plain `meson setup` gives you the build we ship. Turn them on when you are
+chasing a memory bug:
+
+    -Db_sanitize=address,undefined
+
+Expect roughly a 2-4x slowdown with them on, so turn them off again before
+measuring anything.
 
 ## Tests
 

--- a/meson.build
+++ b/meson.build
@@ -5,8 +5,12 @@ project(
   meson_version : '>= 0.59.0',
   default_options: [
     'warning_level=2',
-    'cpp_std=c++17',
-    'b_sanitize=address,undefined',
+    'cpp_std=c++20',
+    # Sanitizers are opt-in, not opt-out: a plain "meson setup" must produce
+    # the build we ship. Enable them explicitly with
+    #   -Db_sanitize=address,undefined
+    # which CI does for the Linux native job. b_lundef stays disabled because
+    # the sanitizer runtimes need it when that option is turned on.
     'b_lundef=false',
     ]
   )

--- a/src/Lib/ArrayUtil/BitArray.cpp
+++ b/src/Lib/ArrayUtil/BitArray.cpp
@@ -16,12 +16,22 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
+#ifndef TEST_LIB
+
 #include "BitArray.hpp"
 
 #include <assert.h>
 #include <string.h>
 
-BitArray::BitArray(void) { array = 0; }
+BitArray::BitArray(void) {
+  array = 0;
+  // Without these, a default-constructed BitArray carries a garbage size,
+  // which is what getBit() bounds-checks against and what clear() passes to
+  // memset. Only initialize() used to set them.
+  size = 0;
+  x_size = 0;
+  y_size = 0;
+}
 
 //************************************************************************
 
@@ -41,9 +51,16 @@ void BitArray::initialize(unsigned long x, unsigned long y) {
   unsigned long rawsize;
   unsigned long remain;
 
-  rawsize = (x * y) / 8;
+  // Round up to whole bytes. The remainder has to be taken on the bit count,
+  // not on the byte count: "rawsize % 8" (with rawsize already bits/8) missed
+  // the extra byte whenever bits/8 landed on a multiple of 8, so x*y of
+  // 65..71, 129..135 and so on under-allocated and the last bits of the array
+  // were written out of bounds.
+  const unsigned long bits = x * y;
 
-  remain = rawsize % 8;
+  rawsize = bits / 8;
+
+  remain = bits % 8;
 
   if (remain) rawsize = rawsize + 1;
 
@@ -106,7 +123,7 @@ void BitArray::clearBit(unsigned long x, unsigned long y) {
 }
 
 //************************************************************************
-bool BitArray::getBit(unsigned long x, unsigned long y) {
+bool BitArray::getBit(unsigned long x, unsigned long y) const {
   if (x >= x_size || y >= y_size) {
     return false;
   }
@@ -121,7 +138,9 @@ bool BitArray::getBit(unsigned long x, unsigned long y) {
   index = index >> 3;
   mask = (mask << shift);
 
-  if (index > size) {
+  // Valid byte indices are 0 .. size-1, so "index > size" let a read run one
+  // byte past the end.
+  if (index >= size) {
     return false;
   }
 
@@ -131,3 +150,120 @@ bool BitArray::getBit(unsigned long x, unsigned long y) {
 
   return (false);
 }
+
+#else
+
+#include "test.hpp"
+
+#include "ArrayUtil/BitArray.hpp"
+
+namespace {
+
+/// Bytes genuinely needed to hold x*y bits.
+unsigned long bytesNeeded(unsigned long x, unsigned long y) {
+  const unsigned long bits = x * y;
+  return (bits + 7) / 8;
+}
+
+}  // namespace
+
+/**
+ * The allocation has to cover every addressable bit. The original rounding
+ * took the remainder of the *byte* count rather than the bit count
+ * (remain = rawsize % 8, where rawsize was already bits/8), which
+ * under-allocates whenever bits/8 lands on a multiple of 8 and the bits do
+ * not divide evenly -- x*y of 65..71, 129..135, and so on.
+ */
+static void testAllocationSize(void) {
+  for (unsigned long bits = 1; bits <= 600; bits++) {
+    BitArray a;
+    a.initialize(bits, 1);
+    assert(a.size >= bytesNeeded(bits, 1));
+  }
+
+  // Two-dimensional shapes take the same path; a map is x by y, not x by 1.
+  for (unsigned long x = 1; x <= 40; x++) {
+    for (unsigned long y = 1; y <= 40; y++) {
+      BitArray a;
+      a.initialize(x, y);
+      assert(a.size >= bytesNeeded(x, y));
+    }
+  }
+}
+
+/**
+ * Touching the last bit of the array must stay inside the allocation. Run
+ * under AddressSanitizer this is the direct test for the bug above; without
+ * it, the size assertions are the safety net.
+ */
+static void testLastBitInBounds(void) {
+  for (unsigned long bits = 1; bits <= 600; bits++) {
+    BitArray a;
+    a.initialize(bits, 1);
+
+    a.setBit(bits - 1, 0);
+    assert(a.getBit(bits - 1, 0));
+
+    a.clearBit(bits - 1, 0);
+    assert(!a.getBit(bits - 1, 0));
+  }
+}
+
+/**
+ * Ordinary set/clear behaviour, including the whole-array helpers.
+ */
+static void testSetAndClear(void) {
+  BitArray a;
+  a.initialize(16, 4);  // 64 bits, an exact byte multiple
+
+  a.clear();
+  for (unsigned long y = 0; y < 4; y++)
+    for (unsigned long x = 0; x < 16; x++) assert(!a.getBit(x, y));
+
+  a.set();
+  for (unsigned long y = 0; y < 4; y++)
+    for (unsigned long x = 0; x < 16; x++) assert(a.getBit(x, y));
+
+  a.clear();
+  a.setBit(3, 2);
+  assert(a.getBit(3, 2));
+  // Setting one bit must not disturb its neighbours.
+  assert(!a.getBit(2, 2));
+  assert(!a.getBit(4, 2));
+  assert(!a.getBit(3, 1));
+  assert(!a.getBit(3, 3));
+}
+
+/**
+ * initialize() is called again on map change, so it has to be safe to reuse
+ * an array and to grow or shrink it.
+ */
+static void testReinitialize(void) {
+  BitArray a;
+  a.initialize(100, 100);
+  a.set();
+  assert(a.getBit(99, 99));
+
+  a.initialize(10, 10);
+  assert(a.size >= bytesNeeded(10, 10));
+  assert(!a.getBit(9, 9));  // initialize() clears
+
+  a.initialize(200, 200);
+  assert(a.size >= bytesNeeded(200, 200));
+  a.setBit(199, 199);
+  assert(a.getBit(199, 199));
+}
+
+int main(int argc, char* argv[]) {
+  (void)argc;
+  (void)argv;
+
+  testAllocationSize();
+  testLastBitInBounds();
+  testSetAndClear();
+  testReinitialize();
+
+  return 0;
+}
+
+#endif

--- a/src/Lib/ArrayUtil/BitArray.cpp
+++ b/src/Lib/ArrayUtil/BitArray.cpp
@@ -153,9 +153,8 @@ bool BitArray::getBit(unsigned long x, unsigned long y) const {
 
 #else
 
-#include "test.hpp"
-
 #include "ArrayUtil/BitArray.hpp"
+#include "test.hpp"
 
 namespace {
 

--- a/src/Lib/ArrayUtil/BitArray.hpp
+++ b/src/Lib/ArrayUtil/BitArray.hpp
@@ -49,7 +49,7 @@ class BitArray : public NoCopy {
 
   void clearBit(unsigned long x, unsigned long y);
 
-  bool getBit(unsigned long x, unsigned long y);
+  bool getBit(unsigned long x, unsigned long y) const;
 };
 
 #endif  // ** _BITARRAY_HPP

--- a/src/NetPanzer/Classes/AI/Astar.cpp
+++ b/src/NetPanzer/Classes/AI/Astar.cpp
@@ -16,7 +16,11 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
+#ifndef TEST_LIB
+
 #include "Astar.hpp"
+
+#include <string.h>
 
 #include <functional>
 
@@ -26,7 +30,55 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #define HEURISTIC_WEIGHT 10
 
-Astar::Astar() { node_list = 0; }
+Astar::Astar() {
+  node_list = 0;
+
+  // Everything below used to be left uninitialised, and one of these fields
+  // decides whether the search writes into astar_set_array -- a BitArray that
+  // is only ever allocated by setDebugMode(). If sample_set_array_flag
+  // happened to come up non-zero, initializePath() set start_sampling_flag,
+  // and process_succ() then called setBit() through a null pointer: a
+  // segfault during pathfinding, dependent on whatever the memory happened to
+  // hold. It reproduces as an immediate crash in a release build while an
+  // AddressSanitizer build, which poisons that memory differently, runs
+  // clean.
+  node_index = 0;
+  node_list_size = 0;
+  free_list_ptr = 0;
+  dynamic_node_management_flag = false;
+
+  best_node = 0;
+
+  sample_set_array_flag = false;
+  start_sampling_flag = false;
+  debug_mode_flag = false;
+
+  steps = 0;
+  step_limit = 0;
+  total_steps = 0;
+  total_pathing_time = 0.0f;
+  heuristic_weight = HEURISTIC_WEIGHT;
+  succ_swap_flag = false;
+  path_type_flag = 0;
+  ini_flag = false;
+
+  path_request_ptr = 0;
+  path_merge_type = 0;
+
+  // The two node structs are plain aggregates and were left as-is until a
+  // search populated them.
+  memset(&current_node, 0, sizeof(current_node));
+  memset(&goal_node, 0, sizeof(goal_node));
+}
+
+Astar::~Astar() {
+  // initializeNodeList() allocates node_list and there was no destructor to
+  // release it. The shipped game only ever builds the two static pathers, so
+  // this leaked once at shutdown rather than growing -- but it also meant any
+  // Astar with automatic or dynamic storage leaked 192 KB per instance.
+  delete[] node_list;
+  node_list = 0;
+}
 
 void Astar::initializeAstar(unsigned long node_list_size,
                             unsigned long step_limit) {
@@ -429,3 +481,256 @@ void Astar::sampleSetArrays() {
 }
 
 BitArray *Astar::getSampledSetArrays() { return &astar_set_array; }
+
+#else
+
+#include "test.hpp"
+
+#include "Astar.hpp"
+#include "Classes/AI/PathList.hpp"
+#include "Classes/Network/NetworkState.hpp"
+#include "Interfaces/GameConfig.hpp"
+#include "Interfaces/MapInterface.hpp"
+#include "Scripts/ScriptManager.hpp"
+
+#include <cstdio>
+#include <vector>
+
+namespace {
+
+/// A path request is answered over several calls, the way PathScheduler
+/// spreads the work across ticks. The bound is a test harness detail: it
+/// turns "the search never terminates" into a failure instead of a hang.
+bool runToCompletion(Astar& astar, PathRequest& request, int* result_code) {
+  const int MAX_ITERATIONS = 200000;
+  for (int i = 0; i < MAX_ITERATIONS; i++) {
+    if (astar.generatePath(&request, _path_merge_front, false, result_code)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool passable(const iXY& loc) {
+  return MapInterface::getMovementValue(loc) != 0xFF;
+}
+
+/// Collect passable tiles spread across the map, so the tests path over real
+/// terrain rather than one hand-picked corner.
+std::vector<iXY> findPassableTiles(size_t wanted) {
+  std::vector<iXY> found;
+  const long w = (long)MapInterface::getWidth();
+  const long h = (long)MapInterface::getHeight();
+
+  // Walk a coarse grid; a diagonal would only ever sample one line of terrain.
+  const long step = 7;
+  for (long y = 1; y < h - 1 && found.size() < wanted; y += step) {
+    for (long x = 1; x < w - 1 && found.size() < wanted; x += step) {
+      const iXY loc(x, y);
+      if (passable(loc)) found.push_back(loc);
+    }
+  }
+  return found;
+}
+
+}  // namespace
+
+/**
+ * The map has to be loaded before any of this means anything; a silently
+ * empty map would make every other assertion below vacuous.
+ */
+static void testMapLoaded(void) {
+  assert(MapInterface::isMapLoaded());
+  assert(MapInterface::getWidth() > 0);
+  assert(MapInterface::getHeight() > 0);
+  printf("  map %zux%zu\n", MapInterface::getWidth(),
+         MapInterface::getHeight());
+  fflush(stdout);
+}
+
+/**
+ * A path between two passable tiles must be found, and the result must be a
+ * real path rather than an empty list reported as success.
+ */
+static void testFindsPath(void) {
+  const std::vector<iXY> tiles = findPassableTiles(64);
+  assert(tiles.size() >= 2);
+
+  Astar astar;
+  astar.initializeAstar(4000, 50);
+
+  const iXY start = tiles.front();
+  const iXY goal = tiles.back();
+
+  PathList path;
+  PathRequest request;
+  UnitID id = 1;
+  iXY s = start, g = goal;
+  request.set(id, s, g, 0, &path, _path_request_full);
+
+  int result_code = -1;
+  assert(runToCompletion(astar, request, &result_code));
+
+  if (result_code == _path_result_success) {
+    // A successful search over distinct tiles must leave steps behind.
+    unsigned long tile = 0;
+    assert(path.popFirst(&tile));
+  } else {
+    // Not every pair on a real map is connected; the only thing that is not
+    // allowed is an undefined answer.
+    assert(result_code == _path_result_goal_unreachable);
+  }
+}
+
+/**
+ * Start equal to goal is a real case -- a unit ordered to where it already
+ * stands -- and must terminate rather than search the whole map.
+ */
+static void testPathToSelf(void) {
+  const std::vector<iXY> tiles = findPassableTiles(1);
+  assert(!tiles.empty());
+
+  Astar astar;
+  astar.initializeAstar(4000, 50);
+
+  PathList path;
+  PathRequest request;
+  UnitID id = 2;
+  iXY s = tiles[0], g = tiles[0];
+  request.set(id, s, g, 0, &path, _path_request_full);
+
+  int result_code = -1;
+  assert(runToCompletion(astar, request, &result_code));
+}
+
+/**
+ * A goal outside the map is reachable from the network: a malformed or
+ * hostile move order carries arbitrary coordinates. The search must
+ * terminate and stay inside its arrays.
+ *
+ * Note what it does *not* assert. An unreachable goal makes the search
+ * expand until the node list is exhausted, and process_succ then does this:
+ *
+ *     if (node == 0) { done = true; goal_reachable = true; // PATCH
+ *
+ * so running out of nodes is reported as _path_result_success with a partial
+ * path towards the goal, not as _path_result_goal_unreachable. That is
+ * deliberate -- the comment says it limits an "unreachable nodes issue", and
+ * units get a partial path instead of refusing to move -- so this test pins
+ * termination and memory safety rather than the result code. Anyone tempted
+ * to tidy that branch up should know the behaviour is load-bearing.
+ */
+static void testGoalOutsideMap(void) {
+  const std::vector<iXY> tiles = findPassableTiles(1);
+  assert(!tiles.empty());
+
+  Astar astar;
+  astar.initializeAstar(4000, 50);
+
+  PathList path;
+  PathRequest request;
+  UnitID id = 3;
+  iXY s = tiles[0];
+  iXY g((long)MapInterface::getWidth() + 500,
+        (long)MapInterface::getHeight() + 500);
+  request.set(id, s, g, 0, &path, _path_request_full);
+
+  int result_code = -1;
+  assert(runToCompletion(astar, request, &result_code));
+  assert(result_code == _path_result_success ||
+         result_code == _path_result_goal_unreachable);
+}
+
+/**
+ * The scheduler reuses one Astar for request after request, so node-list
+ * reset has to leave the searcher in a clean state. Run under
+ * AddressSanitizer this also exercises the open/closed BitArrays, which are
+ * sized from the map dimensions.
+ */
+static void testManyRequestsReuseOneSearcher(void) {
+  const std::vector<iXY> tiles = findPassableTiles(40);
+  assert(tiles.size() >= 4);
+
+  Astar astar;
+  astar.initializeAstar(4000, 50);
+
+  int solved = 0;
+  for (size_t i = 0; i + 1 < tiles.size(); i++) {
+    PathList path;
+    PathRequest request;
+    UnitID id = (UnitID)(100 + i);
+    iXY s = tiles[i], g = tiles[i + 1];
+    request.set(id, s, g, 0, &path, _path_request_full);
+
+    int result_code = -1;
+    assert(runToCompletion(astar, request, &result_code));
+    assert(result_code == _path_result_success ||
+           result_code == _path_result_goal_unreachable);
+    if (result_code == _path_result_success) solved++;
+  }
+
+  // Neighbouring passable tiles on a playable map should mostly connect; if
+  // nothing at all solved, the searcher is broken rather than the terrain.
+  printf("  solved %d of %zu consecutive pairs\n", solved, tiles.size() - 1);
+  fflush(stdout);
+  assert(solved > 0);
+}
+
+/**
+ * The corner tiles are where an under-sized open/closed set shows up first,
+ * because their bit indices land in the final byte of the BitArray.
+ */
+static void testPathsAtMapEdges(void) {
+  const long w = (long)MapInterface::getWidth();
+  const long h = (long)MapInterface::getHeight();
+
+  Astar astar;
+  astar.initializeAstar(4000, 50);
+
+  const iXY corners[] = {iXY(0, 0), iXY(w - 1, 0), iXY(0, h - 1),
+                         iXY(w - 1, h - 1)};
+
+  for (size_t i = 0; i < 4; i++) {
+    for (size_t j = 0; j < 4; j++) {
+      if (i == j) continue;
+
+      PathList path;
+      PathRequest request;
+      UnitID id = (UnitID)(200 + i * 4 + j);
+      iXY s = corners[i], g = corners[j];
+      request.set(id, s, g, 0, &path, _path_request_full);
+
+      int result_code = -1;
+      assert(runToCompletion(astar, request, &result_code));
+    }
+  }
+}
+
+int main(int argc, char* argv[]) {
+  (void)argc;
+
+  filesystem::initialize(argv[0], "test_Astar");
+  Package::assignDataDir();
+  filesystem::addToSearchPath(Package::getDataDir().c_str());
+
+  ScriptManager::initialize();
+
+  // The server path through startMapLoad reads GameConfig::game_mapstyle and
+  // does not need any tile graphics, which is what makes this runnable with
+  // no window.
+  gameconfig = new GameConfig("/config/server.cfg");
+  NetworkState::status = _network_state_server;
+
+  MapInterface::startMapLoad("maps/Two clans", "/SummerDay", false, 0);
+
+  testMapLoaded();
+  testFindsPath();
+  testPathToSelf();
+  testGoalOutsideMap();
+  testManyRequestsReuseOneSearcher();
+  testPathsAtMapEdges();
+
+  return 0;
+}
+
+#endif

--- a/src/NetPanzer/Classes/AI/Astar.cpp
+++ b/src/NetPanzer/Classes/AI/Astar.cpp
@@ -484,7 +484,8 @@ BitArray *Astar::getSampledSetArrays() { return &astar_set_array; }
 
 #else
 
-#include "test.hpp"
+#include <cstdio>
+#include <vector>
 
 #include "Astar.hpp"
 #include "Classes/AI/PathList.hpp"
@@ -492,9 +493,7 @@ BitArray *Astar::getSampledSetArrays() { return &astar_set_array; }
 #include "Interfaces/GameConfig.hpp"
 #include "Interfaces/MapInterface.hpp"
 #include "Scripts/ScriptManager.hpp"
-
-#include <cstdio>
-#include <vector>
+#include "test.hpp"
 
 namespace {
 

--- a/src/NetPanzer/Classes/AI/Astar.hpp
+++ b/src/NetPanzer/Classes/AI/Astar.hpp
@@ -141,6 +141,7 @@ class Astar : private MapInterface {
 
  public:
   Astar();
+  ~Astar();
 
   void initializeAstar(unsigned long node_list_size,
                        unsigned long step_limit = 50);

--- a/src/NetPanzer/Classes/Network/ClientConnectDaemon.cpp
+++ b/src/NetPanzer/Classes/Network/ClientConnectDaemon.cpp
@@ -422,7 +422,13 @@ void ClientConnectDaemon::connectFsm(const NetMessage *message) {
         GameManager::startClientGameSetup(message, &result_code);
 
         if (result_code == _mapload_result_no_map_file) {
-          sprintf(str_buf, "MAP %s NOT FOUND!", game_setup->map_name);
+          // map_name is a fixed 32-byte field straight off the wire and a
+          // hostile server need not terminate it. Plain %s would read past
+          // the field until it happened to find a NUL, overflowing the
+          // 128-byte stack buffer; the precision bounds the read to the
+          // field, and snprintf bounds the write.
+          snprintf(str_buf, sizeof(str_buf), "MAP %.*s NOT FOUND!",
+                   (int)sizeof(game_setup->map_name), game_setup->map_name);
           LoadingView::append(str_buf);
           connection_state = _connect_state_connect_failure;
           failure_display_timer.reset();

--- a/src/NetPanzer/Classes/Network/NetMessageDecoder.cpp
+++ b/src/NetPanzer/Classes/Network/NetMessageDecoder.cpp
@@ -24,6 +24,10 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 NetMessageDecoder::NetMessageDecoder() {
   memset(&decode_message, 0, sizeof(decode_message));
+  // The buffer was cleared but these were not, so a decodeMessage() before
+  // the first setDecodeMessage() did its bounds arithmetic on garbage.
+  size = 0;
+  offset = 0;
 }
 
 NetMessageDecoder::~NetMessageDecoder() {}
@@ -33,6 +37,14 @@ void NetMessageDecoder::setDecodeMessage(const NetMessage* message,
   if (size > sizeof(decode_message)) {
     LOGGER.warning("Multimessage with wrong size!");
     memset(&decode_message, 0, sizeof(decode_message));
+    // The buffer is now empty, so the length describing it has to be too.
+    // Leaving the previous message's size and offset in place meant the next
+    // decodeMessage() walked a zeroed buffer using a stale length -- and on
+    // the first packet, an uninitialised one. The size here comes off the
+    // network, so this path is reachable by anyone who sends an oversized
+    // multi-message.
+    this->size = 0;
+    offset = 0;
     return;
   }
 
@@ -42,7 +54,16 @@ void NetMessageDecoder::setDecodeMessage(const NetMessage* message,
 }
 
 Uint16 NetMessageDecoder::decodeMessage(NetMessage** message) {
-  if (sizeof(NetMessage) + offset >= size) {
+  // Everything past the multi-message header is payload. This arrives
+  // straight off the network, so every bound below has to hold for a packet
+  // that is lying about its contents.
+  const size_t data_len =
+      (size > sizeof(NetMessage)) ? size - sizeof(NetMessage) : 0;
+
+  // The two-byte length prefix must itself be inside the buffer before it can
+  // be read. The old test stopped only once offset reached data_len, so a
+  // packet ending with a single spare byte was read two bytes wide.
+  if (offset + sizeof(Uint16) > data_len) {
     return 0;  // no more messages
   }
 
@@ -50,9 +71,10 @@ Uint16 NetMessageDecoder::decodeMessage(NetMessage** message) {
   memcpy(&mlen_value, decode_message.data + offset, sizeof(Uint16));
   Uint16 msg_len = ltoh16(mlen_value);
 
-  if (msg_len > size - sizeof(NetMessage) - offset) {
+  // The claimed length has to fit in what remains *after* the prefix.
+  if (msg_len > data_len - offset - sizeof(Uint16)) {
     LOGGER.warning("Malformed Multimessage!!");
-    return false;
+    return 0;
   }
 
   *message = (NetMessage*)(decode_message.data + offset + sizeof(Uint16));

--- a/src/NetPanzer/Classes/Network/NetMessageEncoder.cpp
+++ b/src/NetPanzer/Classes/Network/NetMessageEncoder.cpp
@@ -63,12 +63,11 @@ bool NetMessageEncoder::encodeMessage(NetMessage* message, size_t size) {
 
 #else
 
-#include "test.hpp"
-
 #include <string.h>
 
 #include "Classes/Network/NetMessageDecoder.hpp"
 #include "Classes/Network/NetMessageEncoder.hpp"
+#include "test.hpp"
 
 namespace {
 
@@ -104,8 +103,8 @@ static void testEndian(void) {
     assert(btoh16(htob16(val)) == val);
   }
 
-  const Uint32 v32[] = {0u,          1u,          0xFFu,      0x100u,
-                        0xFFFFu,     0x10000u,    0x12345678u, 0xDEADBEEFu,
+  const Uint32 v32[] = {0u,          1u,         0xFFu,       0x100u,
+                        0xFFFFu,     0x10000u,   0x12345678u, 0xDEADBEEFu,
                         0x80000000u, 0xFFFFFFFFu};
   for (size_t i = 0; i < sizeof(v32) / sizeof(v32[0]); i++) {
     assert(ltoh32(htol32(v32[i])) == v32[i]);

--- a/src/NetPanzer/Classes/Network/NetMessageEncoder.cpp
+++ b/src/NetPanzer/Classes/Network/NetMessageEncoder.cpp
@@ -16,6 +16,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
+#ifndef TEST_LIB
+
 #include "Classes/Network/NetMessageEncoder.hpp"
 
 #include <string.h>
@@ -36,7 +38,14 @@ void NetMessageEncoder::resetEncoder() {
 }
 
 bool NetMessageEncoder::encodeMessage(NetMessage* message, size_t size) {
-  if (offset + size >= _MULTI_PACKET_LIMIT) {
+  // Each stored message costs its own size plus the two-byte length prefix
+  // written just below, so the prefix has to be part of the capacity check.
+  // Testing only "offset + size" let a message of exactly
+  // _MULTI_PACKET_LIMIT - 1 bytes through, which then wrote one byte past the
+  // end of encode_message.data. The size check comes first so the addition
+  // cannot wrap.
+  if (size > _MULTI_PACKET_LIMIT ||
+      offset + size + sizeof(Uint16) > _MULTI_PACKET_LIMIT) {
     return false;
   }
 
@@ -51,3 +60,265 @@ bool NetMessageEncoder::encodeMessage(NetMessage* message, size_t size) {
   offset += size + sizeof(Uint16);
   return true;
 }
+
+#else
+
+#include "test.hpp"
+
+#include <string.h>
+
+#include "Classes/Network/NetMessageDecoder.hpp"
+#include "Classes/Network/NetMessageEncoder.hpp"
+
+namespace {
+
+/// A message with a known payload, so a round trip can be checked byte for
+/// byte rather than just "it did not crash".
+struct TestMessage {
+  NetMessage header;
+  Uint8 payload[16];
+};
+
+TestMessage makeMessage(Uint8 id, Uint8 fill) {
+  TestMessage m;
+  m.header.message_class = _net_message_class_player;
+  m.header.message_id = id;
+  memset(m.payload, fill, sizeof(m.payload));
+  return m;
+}
+
+}  // namespace
+
+/**
+ * The codec stores its length prefixes little-endian, so these conversions
+ * sit under every packet the game sends. They are compiled two different
+ * ways depending on WORDS_BIGENDIAN, and only one of those ways is ever
+ * exercised on a given machine -- so check the properties that must hold on
+ * both rather than specific byte orders.
+ */
+static void testEndian(void) {
+  // Round trips must be exact across the whole 16-bit range.
+  for (Uint32 v = 0; v <= 0xFFFF; v++) {
+    const Uint16 val = (Uint16)v;
+    assert(ltoh16(htol16(val)) == val);
+    assert(btoh16(htob16(val)) == val);
+  }
+
+  const Uint32 v32[] = {0u,          1u,          0xFFu,      0x100u,
+                        0xFFFFu,     0x10000u,    0x12345678u, 0xDEADBEEFu,
+                        0x80000000u, 0xFFFFFFFFu};
+  for (size_t i = 0; i < sizeof(v32) / sizeof(v32[0]); i++) {
+    assert(ltoh32(htol32(v32[i])) == v32[i]);
+    assert(btoh32(htob32(v32[i])) == v32[i]);
+  }
+
+  // Exactly one of the two families is a byte swap on any given build, and
+  // the swap has to be a real reversal rather than a no-op.
+  assert(__swap16(0x1234) == 0x3412);
+  assert(__swap32(0x12345678u) == 0x78563412u);
+  assert(__swap16(__swap16(0xABCD)) == 0xABCD);
+  assert(__swap32(__swap32(0xABCDEF01u)) == 0xABCDEF01u);
+
+  // A byte-order conversion must never lose information: distinct inputs stay
+  // distinct. This is what stops a length prefix aliasing onto another.
+  assert(htol16(0x0100) != htol16(0x0001));
+  assert(htob16(0x0100) != htob16(0x0001));
+}
+
+/**
+ * Several messages packed into one multi-message must come back out in the
+ * same order, with the same lengths and the same bytes.
+ */
+static void testRoundTrip(void) {
+  NetMessageEncoder encoder;
+  assert(encoder.isEmpty());
+
+  const int COUNT = 5;
+  TestMessage sent[COUNT];
+  for (int i = 0; i < COUNT; i++) {
+    sent[i] = makeMessage((Uint8)(10 + i), (Uint8)(0xA0 + i));
+    assert(encoder.encodeMessage((NetMessage*)&sent[i], sizeof(TestMessage)));
+  }
+  assert(!encoder.isEmpty());
+
+  NetMessageDecoder decoder;
+  decoder.setDecodeMessage(encoder.getEncodedMessage(),
+                           encoder.getEncodedLen());
+
+  for (int i = 0; i < COUNT; i++) {
+    NetMessage* got = 0;
+    const Uint16 len = decoder.decodeMessage(&got);
+    assert(len == sizeof(TestMessage));
+    assert(got != 0);
+    assert(got->message_class == _net_message_class_player);
+    assert(got->message_id == (Uint8)(10 + i));
+    assert(memcmp(((TestMessage*)got)->payload, sent[i].payload,
+                  sizeof(sent[i].payload)) == 0);
+  }
+
+  // The stream is exhausted; asking again must report so rather than walking
+  // off the end.
+  NetMessage* extra = 0;
+  assert(decoder.decodeMessage(&extra) == 0);
+}
+
+/**
+ * An empty encoder still produces a valid, decodable multi-message that
+ * simply yields nothing.
+ */
+static void testEmpty(void) {
+  NetMessageEncoder encoder;
+  assert(encoder.isEmpty());
+  assert(encoder.getEncodedLen() == sizeof(NetMessage));
+
+  NetMessageDecoder decoder;
+  decoder.setDecodeMessage(encoder.getEncodedMessage(),
+                           encoder.getEncodedLen());
+  NetMessage* got = 0;
+  assert(decoder.decodeMessage(&got) == 0);
+}
+
+/**
+ * The encoder must refuse a message that does not fit. Each stored message
+ * costs its own size plus a two-byte length prefix, so the accounting has to
+ * include that prefix -- otherwise the last accepted message writes past the
+ * end of the buffer.
+ */
+static void testCapacity(void) {
+  NetMessageEncoder encoder;
+
+  // Fill up with a size that divides the buffer awkwardly, so the last
+  // accepted message lands hard against the limit.
+  const size_t CHUNK = 100;
+  Uint8 buf[CHUNK];
+  memset(buf, 0x5A, sizeof(buf));
+  ((NetMessage*)buf)->message_class = _net_message_class_player;
+  ((NetMessage*)buf)->message_id = 1;
+
+  size_t accepted = 0;
+  while (encoder.encodeMessage((NetMessage*)buf, CHUNK)) accepted++;
+  assert(accepted > 0);
+
+  // Everything the encoder claimed to store has to fit inside the packet it
+  // reports, prefixes included.
+  const size_t stored = accepted * (CHUNK + sizeof(Uint16));
+  assert(encoder.getEncodedLen() == stored + sizeof(NetMessage));
+  assert(stored <= _MULTI_PACKET_LIMIT);
+
+  // And it must all decode back out again.
+  NetMessageDecoder decoder;
+  decoder.setDecodeMessage(encoder.getEncodedMessage(),
+                           encoder.getEncodedLen());
+  size_t decoded = 0;
+  NetMessage* got = 0;
+  while (decoder.decodeMessage(&got) != 0) decoded++;
+  assert(decoded == accepted);
+}
+
+/**
+ * The exact boundary. A message of _MULTI_PACKET_LIMIT - 1 bytes passes a
+ * guard written as "offset + size >= limit", because that guard forgets the
+ * two-byte length prefix it is about to write as well. Accepting it writes
+ * one byte past the end of the buffer.
+ */
+static void testCapacityBoundary(void) {
+  static Uint8 big[_MULTI_PACKET_LIMIT];
+  memset(big, 0x77, sizeof(big));
+  ((NetMessage*)big)->message_class = _net_message_class_player;
+  ((NetMessage*)big)->message_id = 2;
+
+  // Largest size that genuinely fits, prefix included.
+  {
+    NetMessageEncoder encoder;
+    const size_t fits = _MULTI_PACKET_LIMIT - sizeof(Uint16);
+    assert(encoder.encodeMessage((NetMessage*)big, fits));
+    assert(encoder.getEncodedLen() ==
+           fits + sizeof(Uint16) + sizeof(NetMessage));
+  }
+
+  // One byte more than fits: must be refused, not silently written.
+  {
+    NetMessageEncoder encoder;
+    const size_t overflows = _MULTI_PACKET_LIMIT - sizeof(Uint16) + 1;
+    assert(!encoder.encodeMessage((NetMessage*)big, overflows));
+    assert(encoder.isEmpty());
+  }
+}
+
+/**
+ * A truncated or lying multi-message arrives from the network like any
+ * other. The decoder must reject it instead of reading past its buffer.
+ */
+static void testMalformed(void) {
+  NetMessageEncoder encoder;
+  TestMessage m = makeMessage(7, 0x33);
+  assert(encoder.encodeMessage((NetMessage*)&m, sizeof(TestMessage)));
+
+  // Claim a payload far longer than the packet actually holds.
+  MultiMessage bad;
+  memcpy(&bad, encoder.getEncodedMessage(), encoder.getEncodedLen());
+  Uint16 lie = htol16(0xFFF0);
+  memcpy(bad.data, &lie, sizeof(Uint16));
+
+  NetMessageDecoder decoder;
+  decoder.setDecodeMessage(&bad, encoder.getEncodedLen());
+  NetMessage* got = 0;
+  assert(decoder.decodeMessage(&got) == 0);
+}
+
+/**
+ * A decoder must be safe before it has been handed anything, and must not
+ * carry state across a rejected packet. Both are reachable from the network:
+ * the size passed to setDecodeMessage comes off the wire, so an oversized
+ * multi-message drives the rejection path.
+ */
+static void testDecoderState(void) {
+  // Fresh decoder, nothing set: must report "no messages" rather than read
+  // uninitialised size and offset.
+  {
+    NetMessageDecoder decoder;
+    NetMessage* got = 0;
+    assert(decoder.decodeMessage(&got) == 0);
+  }
+
+  // A rejected oversized packet must leave the decoder empty, not holding the
+  // previous packet's length over a buffer that has just been zeroed.
+  {
+    NetMessageEncoder encoder;
+    TestMessage m = makeMessage(9, 0x11);
+    assert(encoder.encodeMessage((NetMessage*)&m, sizeof(TestMessage)));
+
+    NetMessageDecoder decoder;
+    decoder.setDecodeMessage(encoder.getEncodedMessage(),
+                             encoder.getEncodedLen());
+
+    NetMessage* got = 0;
+    assert(decoder.decodeMessage(&got) == sizeof(TestMessage));
+
+    // Now hand it something far too big; it has to reset rather than keep the
+    // earlier state.
+    MultiMessage oversized;
+    memset(&oversized, 0, sizeof(oversized));
+    decoder.setDecodeMessage(&oversized, sizeof(oversized) + 1024);
+
+    NetMessage* after = 0;
+    assert(decoder.decodeMessage(&after) == 0);
+  }
+}
+
+int main(int argc, char* argv[]) {
+  (void)argc;
+  (void)argv;
+
+  testEndian();
+  testDecoderState();
+  testRoundTrip();
+  testEmpty();
+  testCapacity();
+  testCapacityBoundary();
+  testMalformed();
+
+  return 0;
+}
+
+#endif

--- a/src/NetPanzer/Interfaces/DedicatedGameManager.cpp
+++ b/src/NetPanzer/Interfaces/DedicatedGameManager.cpp
@@ -222,8 +222,13 @@ bool DedicatedGameManager::mainLoop() {
 
         if (player->getTotal() < GameConfig::game_lowscorelimit + 1) {
           char chat_string_warning_k[140];
-          sprintf(chat_string_warning_k, "Server kicked '%s' due to noobiness!",
-                  player->getName().c_str());
+          // The name is remote input. It fits today only because
+          // PlayerState::setName truncates to 20 characters, three files
+          // away; snprintf means raising that limit cannot turn this into an
+          // overflow.
+          snprintf(chat_string_warning_k, sizeof(chat_string_warning_k),
+                   "Server kicked '%s' due to noobiness!",
+                   player->getName().c_str());
           LOGGER.info("DED: %s", chat_string_warning_k);
           ChatInterface::serversay(chat_string_warning_k);
           SERVER->kickClient(
@@ -245,9 +250,9 @@ bool DedicatedGameManager::mainLoop() {
         if (player->getTotal() < GameConfig::game_lowscorelimit + 10 &&
             player->getTotal() > GameConfig::game_lowscorelimit) {
           char chat_string_warning[140];
-          sprintf(chat_string_warning,
-                  "Warning '%s' - players with %i points or less get kicked!",
-                  player->getName().c_str(), GameConfig::game_lowscorelimit);
+          snprintf(chat_string_warning, sizeof(chat_string_warning),
+                   "Warning '%s' - players with %i points or less get kicked!",
+                   player->getName().c_str(), GameConfig::game_lowscorelimit);
           // ChatInterface::serversay(chat_string_warning);
           ChatInterface::serversayTo(player->getID(), chat_string_warning);
         }

--- a/subprojects/ttf-parser.wrap
+++ b/subprojects/ttf-parser.wrap
@@ -2,4 +2,7 @@
 directory=ttf-parser
 url=https://github.com/RazrFalcon/ttf-parser.git
 depth=1
-revision=master
+# Pinned to a tag rather than a branch: "revision=master" made the build
+# non-reproducible, since an upstream push changed the resulting binary with
+# no corresponding commit here.
+revision=v0.25.1

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -35,9 +35,11 @@ foreach case : test_cases
       # this the data-dependent tests fail for anyone who has not read
       # BUILD.md. Note this points at the "data" directory itself, not at the
       # source root.
-      'NETPANZER_DATADIR=@0@'.format(
-        join_paths(meson.project_source_root(), 'data')
-        )
+      # Built by concatenation rather than join_paths on purpose: the package
+      # test compares against MESON_SOURCE_ROOT "/data" spelled exactly this
+      # way, and on Windows join_paths normalises the source root's
+      # backslashes to forward slashes, so the two stop matching.
+      'NETPANZER_DATADIR=@0@/data'.format(meson.project_source_root())
       ]
     )
 endforeach

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2,7 +2,10 @@ test_cases = [
   '../src/Lib/package',
   '../src/Lib/2D/CachedFontRenderer',
   '../src/Lib/Util/FileSystem',
-  '../src/NetPanzer/Particles/Particle2D'
+  '../src/NetPanzer/Particles/Particle2D',
+  '../src/NetPanzer/Classes/Network/NetMessageEncoder',
+  '../src/Lib/ArrayUtil/BitArray',
+  '../src/NetPanzer/Classes/AI/Astar'
   ]
 
 fs = import('fs')
@@ -28,7 +31,13 @@ foreach case : test_cases
     'test_' + fs.name(case),
     exe,
     env: [
-      # 'NETPANZER_DATADIR="@0@"'.format(meson.project_source_root())
+      # "meson test" does not apply the "meson devenv" environment, so without
+      # this the data-dependent tests fail for anyone who has not read
+      # BUILD.md. Note this points at the "data" directory itself, not at the
+      # source root.
+      'NETPANZER_DATADIR=@0@'.format(
+        join_paths(meson.project_source_root(), 'data')
+        )
       ]
     )
 endforeach

--- a/tests/test.hpp
+++ b/tests/test.hpp
@@ -2,8 +2,12 @@
 // <cassert> or <assert.h> is included, the assertion is disabled: assert does
 // nothing.
 // https://en.cppreference.com/w/cpp/error/assert
+// "#undefine" is not a preprocessor directive, so this never did what it says:
+// with NDEBUG defined it was a hard error rather than a re-enable. The whole
+// suite states its expectations through assert(), so a build that quietly
+// compiled them out would pass without checking anything.
 #ifdef NDEBUG
-#undefine NDEBUG
+#undef NDEBUG
 #endif
 #include <cassert>
 


### PR DESCRIPTION
Makes the test suite runnable, adds tests for the netcode, `BitArray` and A*, and fixes the three bugs those tests found. Independent of my other PRs (no file overlap).

### `meson test` was failing out of the box

Three of the five tests fail on a plain `meson test` today, because only `meson devenv` supplies `NETPANZER_DATADIR`. CI passes only because it sets the variable at job level. `tests/meson.build` now sets it itself: **`Ok: 2 / Fail: 3` becomes `Ok: 8 / Fail: 0`.**

`tests/test.hpp` also said `#undefine NDEBUG`, which is not a preprocessor directive. The suite states every expectation through `assert()`, so a build with `NDEBUG` defined would have failed to compile rather than re-enabling them. Verified both ways: the corrected `#undef` compiles under `-DNDEBUG` and the assert still fires; the old spelling is `error: invalid preprocessing directive #undefine`.

Sanitizers move out of `default_options` into an explicit CI job. They were on for every build including releases unless a packager knew to opt out, which is the wrong polarity for a shipped game and invalidates any measurement taken from a default build. `ttf-parser.wrap` tracked `master`, so the same tree could produce different binaries on different days. `cpp_std` raised to c++20, which compiles clean.

### The bugs the new tests found

**`BitArray` under-allocates by a byte.** `initialize()` rounded up with `remain = rawsize % 8` where `rawsize` was *already* `bits/8` — the remainder of the byte count, not the bit count. Whenever `bits/8` lands on a multiple of 8 and the bits don't divide evenly, it allocates one byte too few. ASan on a direct repro:

```
heap-buffer-overflow, 0 bytes after an 8-byte region, in BitArray::setBit
```

`BitArray` backs A*'s open/closed sets, sized from the map dimensions, so this is reachable in a real game: of the 28 shipped maps, **Crop Circles at 350×350 = 122500 bits allocates 15312 bytes where 15313 are needed**. The overflowing bits are the bottom-right four tiles, so it needs a unit pathing into that corner — I did not observe it fire during 60 s of bot play. `getBit()` also guarded with `index > size` where valid indices stop at `size-1`.

**The multi-message encoder writes one byte past its buffer.** `encodeMessage()` guarded with `offset + size >= _MULTI_PACKET_LIMIT` but then wrote `size` bytes *plus a two-byte length prefix*. The decoder had the mirror problem, and kept the previous message's size/offset when rejecting an oversized packet over a buffer it had just zeroed. Separately, `ClientConnectDaemon` formatted `map_name` — a fixed 32-byte field off the wire that a hostile server need not terminate — into a 128-byte stack buffer with plain `%s`.

**`Astar` left its members uninitialised.** The constructor set only `node_list`. `sample_set_array_flag` decides whether the search writes into `astar_set_array`, a `BitArray` only ever allocated by `setDebugMode()`. gdb on a release build:

```
#0  BitArray::setBit
#1  Astar::process_succ
```

The shipped game does not hit this — its only two `Astar` instances have static storage, which is zero-initialised — but it fires for any `Astar` with automatic or dynamic storage, which is what a test or a second pather creates. `Astar` also had no destructor, so `node_list` leaked 192 KB per instance.

### On the tests themselves

Each was validated by reverting its fix and confirming the test fails, then restoring it. The A* test loads a real map through the dedicated-server path (`startMapLoad(..., load_tiles=false)`, no graphics needed) and paths over real terrain: 39 of 39 consecutive tile pairs solve, plus all 12 corner-to-corner combinations.

One thing the A* test deliberately does *not* assert: on node-list exhaustion `process_succ` sets `goal_reachable = true` and reports success with a partial path. That looks wrong but the comment says it limits an "unreachable nodes issue", so it appears load-bearing — the test pins termination and memory safety instead, and says so, in case someone is tempted to tidy that branch up.

While confirming the above: all four `generatePath()` call sites pass `false` for `dynamic_node_managment`, so the free-list branch in `getNewNode()`/`releaseNode()`/`resetNodeList()` is dead code. Left in place, but worth deleting.
