### PR TITLE
perf: stop reallocating the screen texture every frame

### DIFF
--- a/src/NetPanzer/System/SDLVideo.cpp
+++ b/src/NetPanzer/System/SDLVideo.cpp
@@ -159,7 +159,11 @@ bool SDLVideo::setVideoMode(int new_width, int new_height, int bpp,
   }
 
   LOGGER.debug("Creating new render texture.");
-  texture = SDL_CreateTextureFromSurface(renderer, surface);
+  // Streaming, so render() can write into it instead of allocating a new
+  // texture every frame.
+  texture =
+      SDL_CreateTexture(renderer, SDL_PIXELFORMAT_ARGB8888,
+                        SDL_TEXTUREACCESS_STREAMING, new_width, new_height);
 
   if (texture == nullptr) {
     LOGGER.warning("Couldn't create render texture: %s", SDL_GetError());
@@ -206,13 +210,44 @@ SDL_Surface *SDLVideo::getSurface() { return surface; }
 SDL_Window *SDLVideo::getWindow() { return window; }
 
 void SDLVideo::render() {
-  // This mechanism is only about 5-10% slower than SDL_BlitSurface &&
-  // SDL_UpdateWindowSurface. But, it gets us a lot (simpler code, much nicer
-  // rendering and scaling).
-  if (texture != nullptr) {
-    SDL_DestroyTexture(texture);
+  // The texture is created once in setVideoMode; here the indexed screen is
+  // expanded into it through a palette lookup table.
+  if (texture == nullptr || surface == nullptr) return;
+
+  void *pixels = nullptr;
+  int pitch = 0;
+  if (SDL_LockTexture(texture, nullptr, &pixels, &pitch) != 0) {
+    LOGGER.warning("Couldn't lock render texture: %s", SDL_GetError());
+    return;
   }
-  texture = SDL_CreateTextureFromSurface(renderer, surface);
+
+  // Rebuilt per frame: 256 entries is cheap next to a screen of pixels, and it
+  // stays correct whoever changed the palette since the last one.
+  Uint32 lut[256];
+  const SDL_Palette *pal = surface->format->palette;
+  const int color_count = (pal != nullptr) ? pal->ncolors : 0;
+  for (int i = 0; i < 256; i++) {
+    if (i < color_count) {
+      const SDL_Color &c = pal->colors[i];
+      lut[i] =
+          0xFF000000u | ((Uint32)c.r << 16) | ((Uint32)c.g << 8) | (Uint32)c.b;
+    } else {
+      lut[i] = 0xFF000000u;
+    }
+  }
+
+  const Uint8 *src = (const Uint8 *)surface->pixels;
+  Uint8 *dst = (Uint8 *)pixels;
+  for (int y = 0; y < surface->h; y++) {
+    const Uint8 *src_row = src + (size_t)y * surface->pitch;
+    Uint32 *dst_row = (Uint32 *)(dst + (size_t)y * pitch);
+    for (int x = 0; x < surface->w; x++) {
+      dst_row[x] = lut[src_row[x]];
+    }
+  }
+
+  SDL_UnlockTexture(texture);
+
   SDL_RenderClear(renderer);
   SDL_RenderCopy(renderer, texture, nullptr, nullptr);
   SDL_RenderPresent(renderer);


### PR DESCRIPTION
Narrowed to exactly what you agreed to merge: the per-frame texture allocation, one file, 42 lines. The logical-size/mouse-scaling change, the frame pacing fix, the font cache key fix and the benchmark harness are all gone from this branch.

## What it does

`SDLVideo::render()` destroyed and recreated a full-screen GPU texture on every frame. It is now created once per video mode as a streaming texture, and the indexed screen surface is expanded into it through a palette lookup table.

Over 1500 menu frames: mean 2.755 -> 2.232 ms (-19%), p99 3.608 -> 2.538 ms (-30%), worst frame 13.118 -> 5.453 ms (-58%). Stability improved as much as the mean — the new path held 2.23 ms across repeated runs where the old one ranged from 2.7 to 9.0 ms.

Output is unchanged: both builds screenshotted and diffed, every pixel of game content identical.

## Resolution changes and fullscreen, as requested

Tested on Linux (Debian trixie, GNOME/Wayland, headless virtual display). The video mode was driven through this sequence, each step calling `GameManager::setVideoMode()` exactly as the options menu does:

| step | mode | window after | renders |
|---|---|---|---|
| 0 | 640x480 windowed | 800x637 frame | correct |
| 1 | 800x600 windowed | 800x637 frame | correct |
| 2 | 1024x768 windowed | 1024x805 frame | correct |
| 3 | 1024x768 **fullscreen** | 1280x1024 | correct, letterboxed at the right aspect |
| 4 | 800x600 windowed (back out of fullscreen) | 800x637 frame | correct |

No crash, no corruption, no stale texture at any step, and the round trip out of fullscreen restores cleanly. Each step was screenshotted and checked for real content rather than eyeballed — the logo pixel signature scales proportionally with resolution at every mode.

`setVideoMode()` destroys and recreates the texture at the new size on every mode change, which is the path that matters here: the texture can never outlive the surface it is sized against.

**Not tested on Windows** — I have no Windows machine. That half of your condition is unmet and I would rather say so than imply otherwise. Everything else in the original PR is dropped rather than moved to new PRs; it all lives on my fork if it is ever wanted.